### PR TITLE
build: do not execute integration tests in parallel

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -51,7 +51,7 @@ jobs:
     - name: Integration Tests on Production
       working-directory: ./Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests
       run: |
-        echo "{ \"parallelizeTestCollections\": false }" > xunit.runner.json
+        echo "{ \"parallelizeTestCollections\": true, \"maxParallelThreads\": 2 }" > xunit.runner.json
         dotnet test --verbosity normal
       env:
         JOB_TYPE: test

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -51,7 +51,7 @@ jobs:
     - name: Integration Tests on Production
       working-directory: ./Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests
       run: |
-        echo "{ \"parallelizeTestCollections\": true, \"maxParallelThreads\": 4 }" > xunit.runner.json
+        echo "{ \"parallelizeTestCollections\": true, \"maxParallelThreads\": 1 }" > xunit.runner.json
         dotnet test --verbosity normal
       env:
         JOB_TYPE: test

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -51,7 +51,7 @@ jobs:
     - name: Integration Tests on Production
       working-directory: ./Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests
       run: |
-        echo "{ \"parallelizeTestCollections\": true, \"maxParallelThreads\": 1 }" > xunit.runner.json
+        echo "{ \"parallelizeTestCollections\": false }" > xunit.runner.json
         dotnet test --verbosity normal
       env:
         JOB_TYPE: test

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    timeout-minutes: 10
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     services:
       emulator:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -51,7 +51,7 @@ jobs:
     - name: Integration Tests on Production
       working-directory: ./Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests
       run: |
-        echo "{ \"parallelizeTestCollections\": true, \"maxParallelThreads\": 8 }" > xunit.runner.json
+        echo "{ \"parallelizeTestCollections\": true, \"maxParallelThreads\": 4 }" > xunit.runner.json
         dotnet test --verbosity normal
       env:
         JOB_TYPE: test

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -51,7 +51,7 @@ jobs:
     - name: Integration Tests on Production
       working-directory: ./Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests
       run: |
-        echo "{ \"parallelizeTestCollections\": true, \"maxParallelThreads\": 2 }" > xunit.runner.json
+        echo "{ \"parallelizeTestCollections\": false }" > xunit.runner.json
         dotnet test --verbosity normal
       env:
         JOB_TYPE: test


### PR DESCRIPTION
Disable parallel execution of integration tests on GitHub Actions, as GH otherwise refuses to execute them.