### PR TITLE
feat: alter column migration support

### DIFF
--- a/Google.Cloud.EntityFrameworkCore.Spanner.Tests/Migrations/MigrationSqlGeneratorTestBase.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.Tests/Migrations/MigrationSqlGeneratorTestBase.cs
@@ -707,6 +707,23 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests.Migrations
                 ["UpdateCommitTimestamp"] = SpannerUpdateCommitTimestamp.Never
             });
 
+        public virtual void AlterColumnOperation_Make_type_not_null()
+            => Generate(new AlterColumnOperation
+            {
+                Table = "Singers",
+                Name = "ColLong",
+                ClrType = typeof(long),
+            });
+
+        public virtual void AlterColumnOperation_Make_type_nullable()
+            => Generate(new AlterColumnOperation
+            {
+                Table = "Singers",
+                Name = "ColLong",
+                ClrType = typeof(long),
+                IsNullable = true
+            });
+
         private class VersionedEntity
         {
             public long Version { get; set; }

--- a/Google.Cloud.EntityFrameworkCore.Spanner.Tests/Migrations/MigrationSqlGeneratorTestBase.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.Tests/Migrations/MigrationSqlGeneratorTestBase.cs
@@ -680,6 +680,24 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests.Migrations
                     Values = new object[,] { { "Gregory", "Davis" }, { "Katherine", "Palmer" } }
                 });
 
+        public virtual void AlterColumnOperation()
+            => Generate(new AlterColumnOperation
+            {
+                Table = "Singers",
+                Name = "CharColumn",
+                ClrType = typeof(string),
+                IsNullable = true
+            });
+
+        public virtual void AlterColumnOperation_Add_Commit_Timestamp()
+            => Generate(new AlterColumnOperation
+            {
+                Table = "Singers",
+                Name = "ColCommitTimestamp",
+                ClrType = typeof(DateTime),
+                ["UpdateCommitTimestamp"] = SpannerUpdateCommitTimestamp.OnInsertAndUpdate
+            });
+
         private class VersionedEntity
         {
             public long Version { get; set; }

--- a/Google.Cloud.EntityFrameworkCore.Spanner.Tests/Migrations/MigrationSqlGeneratorTestBase.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.Tests/Migrations/MigrationSqlGeneratorTestBase.cs
@@ -698,6 +698,15 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests.Migrations
                 ["UpdateCommitTimestamp"] = SpannerUpdateCommitTimestamp.OnInsertAndUpdate
             });
 
+        public virtual void AlterColumnOperation_Remove_Commit_Timestamp()
+            => Generate(new AlterColumnOperation
+            {
+                Table = "Singers",
+                Name = "ColCommitTimestamp",
+                ClrType = typeof(DateTime),
+                ["UpdateCommitTimestamp"] = SpannerUpdateCommitTimestamp.Never
+            });
+
         private class VersionedEntity
         {
             public long Version { get; set; }

--- a/Google.Cloud.EntityFrameworkCore.Spanner.Tests/Migrations/SpannerMigrationSqlGeneratorTest.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.Tests/Migrations/SpannerMigrationSqlGeneratorTest.cs
@@ -495,6 +495,20 @@ WHERE SingerId = 4;
 ");
         }
 
+        [Fact]
+        public override void AlterColumnOperation()
+        {
+            base.AlterColumnOperation();
+            AssertSql(@"ALTER TABLE Singers ALTER COLUMN CharColumn STRING(MAX)");
+        }
+
+        [Fact]
+        public override void AlterColumnOperation_Add_Commit_Timestamp()
+        {
+            base.AlterColumnOperation_Add_Commit_Timestamp();
+            AssertSql(@"ALTER TABLE Singers ALTER COLUMN ColCommitTimestamp SET OPTIONS (allow_commit_timestamp=true) ");
+        }
+
         public SpannerMigrationSqlGeneratorTest()
             : base(SpannerTestHelpers.Instance)
         {

--- a/Google.Cloud.EntityFrameworkCore.Spanner.Tests/Migrations/SpannerMigrationSqlGeneratorTest.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.Tests/Migrations/SpannerMigrationSqlGeneratorTest.cs
@@ -509,6 +509,13 @@ WHERE SingerId = 4;
             AssertSql(@"ALTER TABLE Singers ALTER COLUMN ColCommitTimestamp SET OPTIONS (allow_commit_timestamp=true) ");
         }
 
+        [Fact]
+        public override void AlterColumnOperation_Remove_Commit_Timestamp()
+        {
+            base.AlterColumnOperation_Remove_Commit_Timestamp();
+            AssertSql(@"ALTER TABLE Singers ALTER COLUMN ColCommitTimestamp SET OPTIONS (allow_commit_timestamp=null) ");
+        }
+
         public SpannerMigrationSqlGeneratorTest()
             : base(SpannerTestHelpers.Instance)
         {

--- a/Google.Cloud.EntityFrameworkCore.Spanner.Tests/Migrations/SpannerMigrationSqlGeneratorTest.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.Tests/Migrations/SpannerMigrationSqlGeneratorTest.cs
@@ -530,6 +530,19 @@ WHERE SingerId = 4;
             AssertSql(@"ALTER TABLE Singers ALTER COLUMN ColLong INT64");
         }
 
+        [Fact]
+        public virtual void AlterColumnOperation_set_default_value()
+        {
+            Assert.Throws<NotSupportedException>(() => Generate(
+                new AlterColumnOperation
+                {
+                    Table = "Singers",
+                    Name = "Location",
+                    ClrType = typeof(string),
+                    DefaultValue = "London"
+                }));
+        }
+
         public SpannerMigrationSqlGeneratorTest()
             : base(SpannerTestHelpers.Instance)
         {

--- a/Google.Cloud.EntityFrameworkCore.Spanner.Tests/Migrations/SpannerMigrationSqlGeneratorTest.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.Tests/Migrations/SpannerMigrationSqlGeneratorTest.cs
@@ -516,6 +516,20 @@ WHERE SingerId = 4;
             AssertSql(@"ALTER TABLE Singers ALTER COLUMN ColCommitTimestamp SET OPTIONS (allow_commit_timestamp=null) ");
         }
 
+        [Fact]
+        public override void AlterColumnOperation_Make_type_not_null()
+        {
+            base.AlterColumnOperation_Make_type_not_null();
+            AssertSql(@"ALTER TABLE Singers ALTER COLUMN ColLong INT64 NOT NULL");
+        }
+
+        [Fact]
+        public override void AlterColumnOperation_Make_type_nullable()
+        {
+            base.AlterColumnOperation_Make_type_nullable();
+            AssertSql(@"ALTER TABLE Singers ALTER COLUMN ColLong INT64");
+        }
+
         public SpannerMigrationSqlGeneratorTest()
             : base(SpannerTestHelpers.Instance)
         {

--- a/Google.Cloud.EntityFrameworkCore.Spanner/Migrations/SpannerMigrationsSqlGenerator.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner/Migrations/SpannerMigrationsSqlGenerator.cs
@@ -58,9 +58,18 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             var commitTimestampAnnotation = operation.FindAnnotation(SpannerAnnotationNames.UpdateCommitTimestamp);
             if (commitTimestampAnnotation != null)
             {
-                builder
-                    .Append(operation.Name)
-                    .Append(" SET OPTIONS (allow_commit_timestamp=true) ");
+                if ((SpannerUpdateCommitTimestamp)commitTimestampAnnotation.Value == SpannerUpdateCommitTimestamp.Never)
+                {
+                    builder
+                        .Append(operation.Name)
+                        .Append(" SET OPTIONS (allow_commit_timestamp=null) ");
+                }
+                else
+                {
+                    builder
+                        .Append(operation.Name)
+                        .Append(" SET OPTIONS (allow_commit_timestamp=true) ");
+                }
             }
             else
             {

--- a/Google.Cloud.EntityFrameworkCore.Spanner/Migrations/SpannerMigrationsSqlGenerator.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner/Migrations/SpannerMigrationsSqlGenerator.cs
@@ -58,17 +58,17 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             var commitTimestampAnnotation = operation.FindAnnotation(SpannerAnnotationNames.UpdateCommitTimestamp);
             if (commitTimestampAnnotation != null)
             {
-                if ((SpannerUpdateCommitTimestamp)commitTimestampAnnotation.Value == SpannerUpdateCommitTimestamp.Never)
+                if ((SpannerUpdateCommitTimestamp)commitTimestampAnnotation.Value != SpannerUpdateCommitTimestamp.Never)
                 {
                     builder
                         .Append(operation.Name)
-                        .Append(" SET OPTIONS (allow_commit_timestamp=null) ");
+                        .Append(" SET OPTIONS (allow_commit_timestamp=true) ");
                 }
                 else
                 {
                     builder
                         .Append(operation.Name)
-                        .Append(" SET OPTIONS (allow_commit_timestamp=true) ");
+                        .Append(" SET OPTIONS (allow_commit_timestamp=null) ");
                 }
             }
             else


### PR DESCRIPTION
Currently, In Spanner two operation has been perform on column while [updating schema](https://cloud.google.com/spanner/docs/data-definition-language#ddl_syntax).
1. Change Datatype
2. Add `{ OPTIONS ( allow_commit_timestamp = { true | null } ) }` option.
