### PR TITLE
fix: update commit timestamp in column definition

### DIFF
--- a/Google.Cloud.EntityFrameworkCore.Spanner.Tests/Migrations/MigrationSqlGeneratorTestBase.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.Tests/Migrations/MigrationSqlGeneratorTestBase.cs
@@ -437,6 +437,15 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests.Migrations
                 [SpannerAnnotationNames.UpdateCommitTimestamp] = SpannerUpdateCommitTimestamp.OnInsertAndUpdate
             });
 
+        public virtual void AddColumnOperation_with_update_commit_timestamp_never()
+            => Generate(new AddColumnOperation
+            {
+                Table = "Album",
+                Name = "CreatedDate",
+                ClrType = typeof(DateTime),
+                [SpannerAnnotationNames.UpdateCommitTimestamp] = SpannerUpdateCommitTimestamp.Never
+            });
+
         public virtual void AddColumnOperation_without_column_type()
             => Generate(new AddColumnOperation
             {

--- a/Google.Cloud.EntityFrameworkCore.Spanner.Tests/Migrations/SpannerMigrationSqlGeneratorTest.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.Tests/Migrations/SpannerMigrationSqlGeneratorTest.cs
@@ -149,6 +149,14 @@ CONSTRAINT Chk_Title_Length_Equal CHECK (CHARACTER_LENGTH(Title) > 0),
         }
 
         [Fact]
+        public override void AddColumnOperation_with_update_commit_timestamp_never()
+        {
+            base.AddColumnOperation_with_update_commit_timestamp_never();
+            AssertSql(@"ALTER TABLE Album ADD CreatedDate TIMESTAMP NOT NULL OPTIONS (allow_commit_timestamp=null) 
+");
+        }
+
+        [Fact]
         public override void AddColumnOperation_without_column_type()
         {
             base.AddColumnOperation_without_column_type();

--- a/Google.Cloud.EntityFrameworkCore.Spanner/Migrations/SpannerMigrationsSqlGenerator.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner/Migrations/SpannerMigrationsSqlGenerator.cs
@@ -300,7 +300,14 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             var commitTimestampAnnotation = operation.FindAnnotation(SpannerAnnotationNames.UpdateCommitTimestamp);
             if (commitTimestampAnnotation != null)
             {
-                builder.Append(" OPTIONS (allow_commit_timestamp=true) ");
+                if ((SpannerUpdateCommitTimestamp)commitTimestampAnnotation.Value != SpannerUpdateCommitTimestamp.Never)
+                {
+                    builder.Append(" OPTIONS (allow_commit_timestamp=true) ");
+                }
+                else
+                {
+                    builder.Append(" OPTIONS (allow_commit_timestamp=null) ");
+                }
             }
         }
 


### PR DESCRIPTION
Current Implementation was always adding `allow_commit_timestamp=true` even though option set as `Never` while creating column definition.
Now `allow_commit_timestamp` option will be added based on option provided.