### PR TITLE
fix: handle spanner reserved keywords

### DIFF
--- a/Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests/MigrationTests/MigrationModels/AllColType.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests/MigrationTests/MigrationModels/AllColType.cs
@@ -39,6 +39,7 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests
         public float? ColFloat { get; set; }
         public double? ColDouble { get; set; }
         public string ColString { get; set; }
+        public string ASC { get; set; }
         public Guid? ColGuid { get; set; }
         public byte[] ColBytes { get; set; }
         public SpannerNumeric[] ColDecimalArray { get; set; }

--- a/Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests/MigrationTests/Migrations/20210324085522_Initial.Designer.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests/MigrationTests/Migrations/20210324085522_Initial.Designer.cs
@@ -12,7 +12,7 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests.MigrationTests.Migrations
 {
     [DbContext(typeof(TestMigrationDbContext))]
-    [Migration("20210309110114_Initial")]
+    [Migration("20210324085522_Initial")]
     partial class Initial
     {
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
@@ -26,6 +26,9 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests.MigrationTes
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
                         .HasColumnType("INT64");
+
+                    b.Property<string>("ASC")
+                        .HasColumnType("STRING");
 
                     b.Property<bool?>("ColBool")
                         .HasColumnType("BOOL");

--- a/Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests/MigrationTests/Migrations/20210324085522_Initial.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests/MigrationTests/Migrations/20210324085522_Initial.cs
@@ -33,6 +33,7 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests.MigrationTes
                     ColFloat = table.Column<float>(nullable: true),
                     ColDouble = table.Column<double>(nullable: true),
                     ColString = table.Column<string>(nullable: true),
+                    ASC = table.Column<string>(nullable: true),
                     ColGuid = table.Column<Guid>(nullable: true),
                     ColBytes = table.Column<byte[]>(nullable: true),
                     ColDecimalArray = table.Column<SpannerNumeric[]>(nullable: true),

--- a/Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests/MigrationTests/Migrations/TestMigrationDbContextModelSnapshot.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests/MigrationTests/Migrations/TestMigrationDbContextModelSnapshot.cs
@@ -25,6 +25,9 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests.MigrationTes
                         .ValueGeneratedOnAdd()
                         .HasColumnType("INT64");
 
+                    b.Property<string>("ASC")
+                        .HasColumnType("STRING");
+
                     b.Property<bool?>("ColBool")
                         .HasColumnType("BOOL");
 

--- a/Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests/MigrationTests/SpannerMigrationTest.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests/MigrationTests/SpannerMigrationTest.cs
@@ -182,7 +182,8 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests
                     ColSbyte = -120,
                     ColULong = 1000000,
                     ColUShort = 2,
-                    ColChar = 'a'
+                    ColChar = 'a',
+                    ASC = "sample string"
                 };
                 context.AllColTypes.Add(row);
                 var rowCount = await context.SaveChangesAsync();
@@ -228,6 +229,7 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests
                 Assert.Equal((ulong)1000000, row.ColULong);
                 Assert.Equal((ushort)2, row.ColUShort);
                 Assert.Equal('a', row.ColChar);
+                Assert.Equal("sample string", row.ASC);
 
                 // The commit timestamp was automatically set by Cloud Spanner.
                 Assert.NotEqual(new DateTime(), row.ColCommitTimestamp);
@@ -271,6 +273,7 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests
                 row.ColULong = 2000000;
                 row.ColUShort = 5;
                 row.ColChar = 'b';
+                row.ASC = "sample string updated";
                 await context.SaveChangesAsync();
             }
 
@@ -311,6 +314,7 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests
                 Assert.Equal((ulong)2000000, row.ColULong);
                 Assert.Equal((ushort)5, row.ColUShort);
                 Assert.Equal('b', row.ColChar);
+                Assert.Equal("sample string updated", row.ASC);
             }
         }
 

--- a/Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests/Model/TableWithAllColumnTypes.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests/Model/TableWithAllColumnTypes.cs
@@ -29,5 +29,6 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests.Model
         public List<Nullable<SpannerDate>> ColDateArray { get; set; }
         public List<Nullable<DateTime>> ColTimestampArray { get; set; }
         public string ColComputed { get; set; }
+        public string ASC { get; set; }
     }
 }

--- a/Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests/QueryTests.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests/QueryTests.cs
@@ -1298,17 +1298,18 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests
             using var db = new TestSpannerSampleDbContext(_fixture.DatabaseName);
             var id1 = _fixture.RandomLong();
             var id2 = _fixture.RandomLong();
-            db.TableWithAllColumnTypes.AddRange(
+            db.TableWithAllColumnTypes.Add(
                new TableWithAllColumnTypes
                {
                    ColInt64 = id1,
                    ASC = "This is reserved keyword"
-               },
-               new TableWithAllColumnTypes
-               {
-                   ColInt64 = id2,
-                   ASC = "string1"
                });
+            await db.SaveChangesAsync();
+            db.TableWithAllColumnTypes.Add(new TableWithAllColumnTypes
+            {
+                ColInt64 = id2,
+                ASC = "string1"
+            });
             await db.SaveChangesAsync();
 
             // Select query

--- a/Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests/QueryTests.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests/QueryTests.cs
@@ -1314,6 +1314,7 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests
 
             // Select query
             var result = db.TableWithAllColumnTypes
+                .Where(s => new long[] { id1, id2 }.Contains(s.ColInt64))
                 .OrderBy(s => s.ASC)
                 .Select(c => c.ASC).ToList();
             Assert.Collection(result,
@@ -1322,24 +1323,28 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests
 
             // Where clause
             var result1 = db.TableWithAllColumnTypes
+                .Where(s => new long[] { id1, id2 }.Contains(s.ColInt64))
                 .Where(s => s.ASC == "string1")
                 .Select(c => c.ASC).ToList();
             Assert.Collection(result1, s => Assert.Equal("string1", s));
 
             // Start with query
             var result2 = db.TableWithAllColumnTypes
-               .Where(s => s.ASC.StartsWith("This"))
-               .Select(c => c.ASC).ToList();
+                .Where(s => new long[] { id1, id2 }.Contains(s.ColInt64))
+                .Where(s => s.ASC.StartsWith("This"))
+                .Select(c => c.ASC).ToList();
             Assert.Collection(result2, s => Assert.Equal("This is reserved keyword", s));
 
             // Contain query
             var result3 = db.TableWithAllColumnTypes
-               .Where(s => s.ASC.Contains("1"))
-               .Select(c => c.ASC).ToList();
+                .Where(s => new long[] { id1, id2 }.Contains(s.ColInt64))
+                .Where(s => s.ASC.Contains("1"))
+                .Select(c => c.ASC).ToList();
             Assert.Collection(result3, s => Assert.Equal("string1", s));
 
             // Like function
             var result4 = db.TableWithAllColumnTypes
+                .Where(s => new long[] { id1, id2 }.Contains(s.ColInt64))
                 .Where(s => EF.Functions.Like(s.ASC, "%1"))
                 .Select(c => c.ASC).ToList();
             Assert.Collection(result4, s => Assert.Equal("string1", s));

--- a/Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests/SampleDataModel - Emulator.sql
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests/SampleDataModel - Emulator.sql
@@ -81,6 +81,7 @@ CREATE TABLE TableWithAllColumnTypes (
 	ColDateArray ARRAY<DATE>,
 	ColTimestampArray ARRAY<TIMESTAMP>,
 	ColComputed STRING(MAX),
+	`ASC` STRING(MAX),
 ) PRIMARY KEY (ColInt64);
 
 CREATE NULL_FILTERED INDEX IDX_TableWithAllColumnTypes_ColDate_ColCommitTS ON TableWithAllColumnTypes (ColDate, ColCommitTS);

--- a/Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests/SampleDataModel.sql
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests/SampleDataModel.sql
@@ -82,6 +82,7 @@ CREATE TABLE TableWithAllColumnTypes (
 	ColDateArray ARRAY<DATE>,
 	ColTimestampArray ARRAY<TIMESTAMP>,
 	ColComputed STRING(MAX) AS (ARRAY_TO_STRING(ColStringArray, ',')) STORED,
+	`ASC` STRING(MAX),
 ) PRIMARY KEY (ColInt64);
 
 CREATE NULL_FILTERED INDEX IDX_TableWithAllColumnTypes_ColDate_ColCommitTS ON TableWithAllColumnTypes (ColDate, ColCommitTS);

--- a/Google.Cloud.EntityFrameworkCore.Spanner.Tests/EntityFrameworkMockServerTests.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.Tests/EntityFrameworkMockServerTests.cs
@@ -90,7 +90,9 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
         [Fact]
         public async Task FindSingerAsync_ReturnsNull_IfNotFound()
         {
-            var sql = $"SELECT s.SingerId, s.BirthDate, s.FirstName, s.FullName, s.LastName, s.Picture{Environment.NewLine}FROM Singers AS s{Environment.NewLine}WHERE s.SingerId = @__p_0{Environment.NewLine}LIMIT 1";
+            var sql = $"SELECT `s`.`SingerId`, `s`.`BirthDate`, `s`.`FirstName`, `s`.`FullName`, `s`.`LastName`, " +
+                $"`s`.`Picture`{Environment.NewLine}FROM `Singers` AS `s`{Environment.NewLine}" +
+                $"WHERE `s`.`SingerId` = @__p_0{Environment.NewLine}LIMIT 1";
             _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateResultSet(
                 new List<Tuple<V1.Type, string>> { },
                 new List<object[]> { }
@@ -104,7 +106,9 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
         [Fact]
         public async Task FindSingerAsync_ReturnsInstance_IfFound()
         {
-            var sql = AddFindSingerResult($"SELECT s.SingerId, s.BirthDate, s.FirstName, s.FullName, s.LastName, s.Picture{Environment.NewLine}FROM Singers AS s{Environment.NewLine}WHERE s.SingerId = @__p_0{Environment.NewLine}LIMIT 1");
+            var sql = AddFindSingerResult($"SELECT `s`.`SingerId`, `s`.`BirthDate`, `s`.`FirstName`, `s`.`FullName`, " +
+                $"`s`.`LastName`, `s`.`Picture`{Environment.NewLine}FROM `Singers` AS `s`{Environment.NewLine}" +
+                $"WHERE `s`.`SingerId` = @__p_0{Environment.NewLine}LIMIT 1");
 
             using var db = new MockServerSampleDbContext(ConnectionString);
             var singer = await db.Singers.FindAsync(1L);
@@ -131,7 +135,8 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
         public async Task InsertSinger_SelectsFullName()
         {
             // Setup results.
-            var insertSql = $"INSERT INTO Singers (SingerId, BirthDate, FirstName, LastName, Picture){Environment.NewLine}VALUES (@p0, @p1, @p2, @p3, @p4)";
+            var insertSql = $"INSERT INTO `Singers` (`SingerId`, `BirthDate`, `FirstName`, `LastName`, `Picture`)" +
+                $"{Environment.NewLine}VALUES (@p0, @p1, @p2, @p3, @p4)";
             _fixture.SpannerMock.AddOrUpdateStatementResult(insertSql, StatementResult.CreateUpdateCount(1L));
             var selectFullNameSql = AddSelectSingerFullNameResult("Alice Morrison", 0);
 
@@ -169,9 +174,11 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
         public async Task UpdateSinger_SelectsFullName()
         {
             // Setup results.
-            var updateSql = $"UPDATE Singers SET LastName = @p0{Environment.NewLine}WHERE SingerId = @p1";
+            var updateSql = $"UPDATE `Singers` SET `LastName` = @p0{Environment.NewLine}WHERE `SingerId` = @p1";
             _fixture.SpannerMock.AddOrUpdateStatementResult(updateSql, StatementResult.CreateUpdateCount(1L));
-            var selectSingerSql = AddFindSingerResult($"SELECT s.SingerId, s.BirthDate, s.FirstName, s.FullName, s.LastName, s.Picture{Environment.NewLine}FROM Singers AS s{Environment.NewLine}WHERE s.SingerId = @__p_0{Environment.NewLine}LIMIT 1");
+            var selectSingerSql = AddFindSingerResult($"SELECT `s`.`SingerId`, `s`.`BirthDate`, `s`.`FirstName`, " +
+                $"`s`.`FullName`, `s`.`LastName`, `s`.`Picture`{Environment.NewLine}FROM `Singers` AS `s`{Environment.NewLine}" +
+                $"WHERE `s`.`SingerId` = @__p_0{Environment.NewLine}LIMIT 1");
             var selectFullNameSql = AddSelectSingerFullNameResult("Alice Pieterson-Morrison", 1);
 
             using var db = new MockServerSampleDbContext(ConnectionString);
@@ -209,7 +216,7 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
         public async Task DeleteSinger_DoesNotSelectFullName()
         {
             // Setup results.
-            var deleteSql = $"DELETE FROM Singers{Environment.NewLine}WHERE SingerId = @p0";
+            var deleteSql = $"DELETE FROM `Singers`{Environment.NewLine}WHERE `SingerId` = @p0";
             _fixture.SpannerMock.AddOrUpdateStatementResult(deleteSql, StatementResult.CreateUpdateCount(1L));
 
             using var db = new MockServerSampleDbContext(ConnectionString);
@@ -233,7 +240,9 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
         [Fact]
         public async Task CanUseReadOnlyTransaction()
         {
-            var sql = AddFindSingerResult($"SELECT s.SingerId, s.BirthDate, s.FirstName, s.FullName, s.LastName, s.Picture{Environment.NewLine}FROM Singers AS s{Environment.NewLine}WHERE s.SingerId = @__p_0{Environment.NewLine}LIMIT 1");
+            var sql = AddFindSingerResult($"SELECT `s`.`SingerId`, `s`.`BirthDate`, `s`.`FirstName`, `s`.`FullName`," +
+                $" `s`.`LastName`, `s`.`Picture`{Environment.NewLine}FROM `Singers` AS `s`{Environment.NewLine}" +
+                $"WHERE `s`.`SingerId` = @__p_0{Environment.NewLine}LIMIT 1");
             using var db = new MockServerSampleDbContext(ConnectionString);
             using var transaction = await db.Database.BeginReadOnlyTransactionAsync();
 
@@ -256,7 +265,9 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
         [Fact]
         public async Task CanUseReadOnlyTransactionWithTimestampBound()
         {
-            var sql = AddFindSingerResult($"SELECT s.SingerId, s.BirthDate, s.FirstName, s.FullName, s.LastName, s.Picture{Environment.NewLine}FROM Singers AS s{Environment.NewLine}WHERE s.SingerId = @__p_0{Environment.NewLine}LIMIT 1");
+            var sql = AddFindSingerResult($"SELECT `s`.`SingerId`, `s`.`BirthDate`, `s`.`FirstName`, `s`.`FullName`," +
+                $" `s`.`LastName`, `s`.`Picture`{Environment.NewLine}FROM `Singers` AS `s`{Environment.NewLine}" +
+                $"WHERE `s`.`SingerId` = @__p_0{Environment.NewLine}LIMIT 1");
             using var db = new MockServerSampleDbContext(ConnectionString);
             using var transaction = await db.Database.BeginReadOnlyTransactionAsync(TimestampBound.OfExactStaleness(TimeSpan.FromSeconds(10)));
 
@@ -283,11 +294,11 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
             var today = SpannerDate.FromDateTime(DateTime.SpecifyKind(DateTime.Today, DateTimeKind.Unspecified));
             var now = DateTime.UtcNow;
             var id = 1L;
-            var rawSql = @$"INSERT INTO TableWithAllColumnTypes 
-                              (ColBool, ColBoolArray, ColBytes, ColBytesMax, ColBytesArray, ColBytesMaxArray,
-                               ColDate, ColDateArray, ColFloat64, ColFloat64Array, ColInt64, ColInt64Array,
-                               ColNumeric, ColNumericArray, ColString, ColStringArray, ColStringMax, ColStringMaxArray,
-                               ColTimestamp, ColTimestampArray)
+            var rawSql = @$"INSERT INTO `TableWithAllColumnTypes` 
+                              (`ColBool`, `ColBoolArray`, `ColBytes`, `ColBytesMax`, `ColBytesArray`, `ColBytesMaxArray`,
+                               `ColDate`, `ColDateArray`, `ColFloat64`, `ColFloat64Array`, `ColInt64`, `ColInt64Array`,
+                               `ColNumeric`, `ColNumericArray`, `ColString`, `ColStringArray`, `ColStringMax`, `ColStringMaxArray`,
+                               `ColTimestamp`, `ColTimestampArray`)
                               VALUES
                               (@ColBool, @ColBoolArray, @ColBytes, @ColBytesMax, @ColBytesArray, @ColBytesMaxArray,
                                @ColDate, @ColDateArray, @ColFloat64, @ColFloat64Array, @ColInt64, @ColInt64Array,
@@ -352,7 +363,8 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
         [Fact]
         public async Task VersionNumberIsAutomaticallyGeneratedOnInsertAndUpdate()
         {
-            var insertSql = $"INSERT INTO SingersWithVersion (SingerId, FirstName, LastName, Version){Environment.NewLine}VALUES (@p0, @p1, @p2, @p3)";
+            var insertSql = $"INSERT INTO `SingersWithVersion` (`SingerId`, `FirstName`, `LastName`, `Version`)" +
+                $"{Environment.NewLine}VALUES (@p0, @p1, @p2, @p3)";
             _fixture.SpannerMock.AddOrUpdateStatementResult(insertSql, StatementResult.CreateUpdateCount(1L));
             using var db = new MockServerVersionDbContext(ConnectionString);
             var singer = new SingersWithVersion { SingerId = 1L, FirstName = "Pete", LastName = "Allison" };
@@ -376,7 +388,8 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
 
             _fixture.SpannerMock.Reset();
             // Update the singer and verify that the version number is included in the WHERE clause and is updated.
-            var updateSql = $"UPDATE SingersWithVersion SET LastName = @p0, Version = @p1{Environment.NewLine}WHERE SingerId = @p2 AND Version = @p3";
+            var updateSql = $"UPDATE `SingersWithVersion` SET `LastName` = @p0, `Version` = @p1" +
+                $"{Environment.NewLine}WHERE `SingerId` = @p2 AND `Version` = @p3";
             _fixture.SpannerMock.AddOrUpdateStatementResult(updateSql, StatementResult.CreateUpdateCount(1L));
 
             singer.LastName = "Peterson - Allison";
@@ -403,7 +416,8 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
         [Fact]
         public async Task UpdateFailsIfVersionNumberChanged()
         {
-            var updateSql = $"UPDATE SingersWithVersion SET LastName = @p0, Version = @p1{Environment.NewLine}WHERE SingerId = @p2 AND Version = @p3";
+            var updateSql = $"UPDATE `SingersWithVersion` SET `LastName` = @p0, `Version` = @p1" +
+                $"{Environment.NewLine}WHERE `SingerId` = @p2 AND `Version` = @p3";
             // Set the update count to 0 to indicate that the row was not found.
             _fixture.SpannerMock.AddOrUpdateStatementResult(updateSql, StatementResult.CreateUpdateCount(0L));
             using var db = new MockServerVersionDbContext(ConnectionString);
@@ -428,7 +442,8 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
         public async Task ExplicitAndImplicitTransactionIsRetried(bool disableInternalRetries, bool useExplicitTransaction)
         {
             // Setup results.
-            var insertSql = $"INSERT INTO Venues (Code, Active, Capacity, Name, Ratings){Environment.NewLine}VALUES (@p0, @p1, @p2, @p3, @p4)";
+            var insertSql = $"INSERT INTO `Venues` (`Code`, `Active`, `Capacity`, `Name`, `Ratings`)" +
+                $"{Environment.NewLine}VALUES (@p0, @p1, @p2, @p3, @p4)";
             _fixture.SpannerMock.AddOrUpdateStatementResult(insertSql, StatementResult.CreateUpdateCount(1L));
             // Abort the next statement that is executed on the mock server.
             _fixture.SpannerMock.AbortNextStatement();
@@ -493,7 +508,8 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
         public async Task ExplicitAndImplicitTransactionIsRetried_WhenUsingRawSql(bool disableInternalRetries, bool useExplicitTransaction)
         {
             // Setup results.
-            var insertSql = $"INSERT INTO Venues (Code, Active, Capacity, Name, Ratings){Environment.NewLine}VALUES (@p0, @p1, @p2, @p3, @p4)";
+            var insertSql = $"INSERT INTO `Venues` (`Code`, `Active`, `Capacity`, `Name`, `Ratings`)" +
+                $"{Environment.NewLine}VALUES (@p0, @p1, @p2, @p3, @p4)";
             _fixture.SpannerMock.AddOrUpdateStatementResult(insertSql, StatementResult.CreateUpdateCount(1L));
             // Abort the next statement that is executed on the mock server.
             _fixture.SpannerMock.AbortNextStatement();
@@ -559,7 +575,9 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
         public async Task CanUseLimitWithoutOffset()
         {
             using var db = new MockServerSampleDbContext(ConnectionString);
-            var sql = $"SELECT s.SingerId, s.BirthDate, s.FirstName, s.FullName, s.LastName, s.Picture{Environment.NewLine}FROM Singers AS s{Environment.NewLine}ORDER BY s.LastName{Environment.NewLine}LIMIT @__p_0";
+            var sql = $"SELECT `s`.`SingerId`, `s`.`BirthDate`, `s`.`FirstName`, `s`.`FullName`, `s`.`LastName`, " +
+                $"`s`.`Picture`{Environment.NewLine}FROM `Singers` AS `s`{Environment.NewLine}ORDER BY `s`.`LastName`" +
+                $"{Environment.NewLine}LIMIT @__p_0";
             AddFindSingerResult(sql);
 
             var singers = await db.Singers
@@ -582,7 +600,9 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
         public async Task CanUseLimitWithOffset()
         {
             using var db = new MockServerSampleDbContext(ConnectionString);
-            var sql = $"SELECT s.SingerId, s.BirthDate, s.FirstName, s.FullName, s.LastName, s.Picture{Environment.NewLine}FROM Singers AS s{Environment.NewLine}ORDER BY s.LastName{Environment.NewLine}LIMIT @__p_1 OFFSET @__p_0";
+            var sql = $"SELECT `s`.`SingerId`, `s`.`BirthDate`, `s`.`FirstName`, `s`.`FullName`, `s`.`LastName`, " +
+                $"`s`.`Picture`{Environment.NewLine}FROM `Singers` AS `s`{Environment.NewLine}" +
+                $"ORDER BY `s`.`LastName`{Environment.NewLine}LIMIT @__p_1 OFFSET @__p_0";
             AddFindSingerResult(sql);
 
             var singers = await db.Singers
@@ -607,7 +627,9 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
         public async Task CanUseOffsetWithoutLimit()
         {
             using var db = new MockServerSampleDbContext(ConnectionString);
-            var sql = $"SELECT s.SingerId, s.BirthDate, s.FirstName, s.FullName, s.LastName, s.Picture{Environment.NewLine}FROM Singers AS s{Environment.NewLine}ORDER BY s.LastName{Environment.NewLine}LIMIT {long.MaxValue / 2} OFFSET @__p_0";
+            var sql = $"SELECT `s`.`SingerId`, `s`.`BirthDate`, `s`.`FirstName`, `s`.`FullName`, `s`.`LastName`, " +
+                $"`s`.`Picture`{Environment.NewLine}FROM `Singers` AS `s`{Environment.NewLine}" +
+                $"ORDER BY `s`.`LastName`{Environment.NewLine}LIMIT {long.MaxValue / 2} OFFSET @__p_0";
             AddFindSingerResult(sql);
 
             var singers = await db.Singers
@@ -630,7 +652,9 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
         public async Task CanUseInnerJoin()
         {
             using var db = new MockServerSampleDbContext(ConnectionString);
-            var sql = $"SELECT s.SingerId, s.BirthDate, s.FirstName, s.FullName, s.LastName, s.Picture, a.AlbumId, a.ReleaseDate, a.SingerId, a.Title{Environment.NewLine}FROM Singers AS s{Environment.NewLine}INNER JOIN Albums AS a ON s.SingerId = a.SingerId";
+            var sql = $"SELECT `s`.`SingerId`, `s`.`BirthDate`, `s`.`FirstName`, `s`.`FullName`, `s`.`LastName`, " +
+                $"`s`.`Picture`, `a`.`AlbumId`, `a`.`ReleaseDate`, `a`.`SingerId`, `a`.`Title`{Environment.NewLine}" +
+                $"FROM `Singers` AS `s`{Environment.NewLine}INNER JOIN `Albums` AS `a` ON `s`.`SingerId` = `a`.`SingerId`";
             _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateResultSet(
                 new List<Tuple<V1.TypeCode, string>>
                 {
@@ -668,7 +692,9 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
         public async Task CanUseOuterJoin()
         {
             using var db = new MockServerSampleDbContext(ConnectionString);
-            var sql = $"SELECT s.SingerId, s.BirthDate, s.FirstName, s.FullName, s.LastName, s.Picture, a.AlbumId, a.ReleaseDate, a.SingerId, a.Title{Environment.NewLine}FROM Singers AS s{Environment.NewLine}LEFT JOIN Albums AS a ON s.SingerId = a.SingerId";
+            var sql = $"SELECT `s`.`SingerId`, `s`.`BirthDate`, `s`.`FirstName`, `s`.`FullName`, `s`.`LastName`, " +
+                $"`s`.`Picture`, `a`.`AlbumId`, `a`.`ReleaseDate`, `a`.`SingerId`, `a`.`Title`{Environment.NewLine}" +
+                $"FROM `Singers` AS `s`{Environment.NewLine}LEFT JOIN `Albums` AS `a` ON `s`.`SingerId` = `a`.`SingerId`";
             _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateResultSet(
                 new List<Tuple<V1.TypeCode, string>>
                 {
@@ -716,7 +742,9 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
         public async Task CanUseStringContains()
         {
             using var db = new MockServerSampleDbContext(ConnectionString);
-            var sql = $"SELECT s.SingerId, s.BirthDate, s.FirstName, s.FullName, s.LastName, s.Picture{Environment.NewLine}FROM Singers AS s{Environment.NewLine}WHERE STRPOS(s.FirstName, @__firstName_0) > 0";
+            var sql = $"SELECT `s`.`SingerId`, `s`.`BirthDate`, `s`.`FirstName`, `s`.`FullName`, `s`.`LastName`, " +
+                $"`s`.`Picture`{Environment.NewLine}FROM `Singers` AS `s`{Environment.NewLine}" +
+                $"WHERE STRPOS(`s`.`FirstName`, @__firstName_0) > 0";
             AddFindSingerResult(sql);
 
             var firstName = "Alice";
@@ -739,7 +767,9 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
         public async Task CanUseStringStartsWith()
         {
             using var db = new MockServerSampleDbContext(ConnectionString);
-            var sql = $"SELECT s.SingerId, s.BirthDate, s.FirstName, s.FullName, s.LastName, s.Picture{Environment.NewLine}FROM Singers AS s{Environment.NewLine}WHERE (@__fullName_0 = '') OR STARTS_WITH(s.FullName, @__fullName_0)";
+            var sql = $"SELECT `s`.`SingerId`, `s`.`BirthDate`, `s`.`FirstName`, `s`.`FullName`, `s`.`LastName`, " +
+                $"`s`.`Picture`{Environment.NewLine}FROM `Singers` AS `s`{Environment.NewLine}" +
+                $"WHERE (@__fullName_0 = '') OR STARTS_WITH(`s`.`FullName`, @__fullName_0)";
             AddFindSingerResult(sql);
 
             var fullName = "Alice M";
@@ -762,7 +792,9 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
         public async Task CanUseStringEndsWith()
         {
             using var db = new MockServerSampleDbContext(ConnectionString);
-            var sql = $"SELECT s.SingerId, s.BirthDate, s.FirstName, s.FullName, s.LastName, s.Picture{Environment.NewLine}FROM Singers AS s{Environment.NewLine}WHERE (@__fullName_0 = '') OR ENDS_WITH(s.FullName, @__fullName_0)";
+            var sql = $"SELECT `s`.`SingerId`, `s`.`BirthDate`, `s`.`FirstName`, `s`.`FullName`, `s`.`LastName`, " +
+                $"`s`.`Picture`{Environment.NewLine}FROM `Singers` AS `s`{Environment.NewLine}" +
+                $"WHERE (@__fullName_0 = '') OR ENDS_WITH(`s`.`FullName`, @__fullName_0)";
             AddFindSingerResult(sql);
 
             var fullName = " Morrison";
@@ -785,7 +817,9 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
         public async Task CanUseStringLength()
         {
             using var db = new MockServerSampleDbContext(ConnectionString);
-            var sql = $"SELECT s.SingerId, s.BirthDate, s.FirstName, s.FullName, s.LastName, s.Picture{Environment.NewLine}FROM Singers AS s{Environment.NewLine}WHERE CHAR_LENGTH(s.FirstName) > @__minLength_0";
+            var sql = $"SELECT `s`.`SingerId`, `s`.`BirthDate`, `s`.`FirstName`, `s`.`FullName`, `s`.`LastName`, " +
+                $"`s`.`Picture`{Environment.NewLine}FROM `Singers` AS `s`{Environment.NewLine}" +
+                $"WHERE CHAR_LENGTH(`s`.`FirstName`) > @__minLength_0";
             AddFindSingerResult(sql);
 
             var minLength = 4;
@@ -808,7 +842,8 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
         public async Task CanUseRegexReplace()
         {
             using var db = new MockServerSampleDbContext(ConnectionString);
-            var sql = $"SELECT REGEXP_REPLACE(s.FirstName, @__regex_1, @__replacement_2){Environment.NewLine}FROM Singers AS s{Environment.NewLine}WHERE s.SingerId = @__singerId_0";
+            var sql = $"SELECT REGEXP_REPLACE(`s`.`FirstName`, @__regex_1, @__replacement_2)" +
+                $"{Environment.NewLine}FROM `Singers` AS `s`{Environment.NewLine}WHERE `s`.`SingerId` = @__singerId_0";
             _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateResultSet(
                 new List<Tuple<V1.TypeCode, string>>
                 {
@@ -836,7 +871,8 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
         {
             using var db = new MockServerSampleDbContext(ConnectionString);
             // Note: AddYears cannot be applied server side to a TIMESTAMP, only to a DATE, so this is handled client side.
-            var sql = $"SELECT c.StartTime{Environment.NewLine}FROM Concerts AS c{Environment.NewLine}WHERE c.SingerId = @__singerId_0";
+            var sql = $"SELECT `c`.`StartTime`{Environment.NewLine}FROM `Concerts` AS `c`" +
+                $"{Environment.NewLine}WHERE `c`.`SingerId` = @__singerId_0";
             _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateResultSet(
                 new List<Tuple<V1.TypeCode, string>>
                 {
@@ -860,7 +896,9 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
         public async Task CanUseSpannerDateAddYears()
         {
             using var db = new MockServerSampleDbContext(ConnectionString);
-            var sql = $"SELECT DATE_ADD(s.BirthDate, INTERVAL 1 YEAR){Environment.NewLine}FROM Singers AS s{Environment.NewLine}WHERE (s.SingerId = @__singerId_0) AND s.BirthDate IS NOT NULL";
+            var sql = $"SELECT DATE_ADD(`s`.`BirthDate`, INTERVAL 1 YEAR){Environment.NewLine}" +
+                $"FROM `Singers` AS `s`{Environment.NewLine}WHERE (`s`.`SingerId` = @__singerId_0) " +
+                $"AND `s`.`BirthDate` IS NOT NULL";
             _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateResultSet(
                 new List<Tuple<V1.TypeCode, string>>
                 {
@@ -885,7 +923,8 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
         {
             using var db = new MockServerSampleDbContext(ConnectionString);
             // Note: AddMonths cannot be applied server side to a TIMESTAMP, only to a DATE, so this is handled client side.
-            var sql = $"SELECT c.StartTime{Environment.NewLine}FROM Concerts AS c{Environment.NewLine}WHERE c.SingerId = @__singerId_0";
+            var sql = $"SELECT `c`.`StartTime`{Environment.NewLine}FROM `Concerts` AS `c`" +
+                $"{Environment.NewLine}WHERE `c`.`SingerId` = @__singerId_0";
             _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateResultSet(
                 new List<Tuple<V1.TypeCode, string>>
                 {
@@ -909,7 +948,9 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
         public async Task CanUseSpannerDateAddMonths()
         {
             using var db = new MockServerSampleDbContext(ConnectionString);
-            var sql = $"SELECT DATE_ADD(s.BirthDate, INTERVAL 1 MONTH){Environment.NewLine}FROM Singers AS s{Environment.NewLine}WHERE (s.SingerId = @__singerId_0) AND s.BirthDate IS NOT NULL";
+            var sql = $"SELECT DATE_ADD(`s`.`BirthDate`, INTERVAL 1 MONTH){Environment.NewLine}" +
+                $"FROM `Singers` AS `s`{Environment.NewLine}WHERE (`s`.`SingerId` = @__singerId_0) " +
+                $"AND `s`.`BirthDate` IS NOT NULL";
             _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateResultSet(
                 new List<Tuple<V1.TypeCode, string>>
                 {
@@ -933,7 +974,9 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
         public async Task CanUseDateTimeAddDays()
         {
             using var db = new MockServerSampleDbContext(ConnectionString);
-            var sql = $"SELECT TIMESTAMP_ADD(c.StartTime, INTERVAL CAST(1.0 AS INT64) DAY){Environment.NewLine}FROM Concerts AS c{Environment.NewLine}WHERE c.SingerId = @__singerId_0";
+            var sql = $"SELECT TIMESTAMP_ADD(`c`.`StartTime`, INTERVAL CAST(1.0 AS INT64) DAY)" +
+                $"{Environment.NewLine}FROM `Concerts` AS `c`{Environment.NewLine}" +
+                $"WHERE `c`.`SingerId` = @__singerId_0";
             _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateResultSet(
                 new List<Tuple<V1.TypeCode, string>>
                 {
@@ -957,7 +1000,9 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
         public async Task CanUseSpannerDateAddDays()
         {
             using var db = new MockServerSampleDbContext(ConnectionString);
-            var sql = $"SELECT DATE_ADD(s.BirthDate, INTERVAL 1 DAY){Environment.NewLine}FROM Singers AS s{Environment.NewLine}WHERE (s.SingerId = @__singerId_0) AND s.BirthDate IS NOT NULL";
+            var sql = $"SELECT DATE_ADD(`s`.`BirthDate`, INTERVAL 1 DAY){Environment.NewLine}" +
+                $"FROM `Singers` AS `s`{Environment.NewLine}WHERE (`s`.`SingerId` = @__singerId_0) " +
+                $"AND `s`.`BirthDate` IS NOT NULL";
             _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateResultSet(
                 new List<Tuple<V1.TypeCode, string>>
                 {
@@ -981,7 +1026,9 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
         public async Task CanUseDateTimeAddHours()
         {
             using var db = new MockServerSampleDbContext(ConnectionString);
-            var sql = $"SELECT TIMESTAMP_ADD(c.StartTime, INTERVAL CAST(1.0 AS INT64) HOUR){Environment.NewLine}FROM Concerts AS c{Environment.NewLine}WHERE c.SingerId = @__singerId_0";
+            var sql = $"SELECT TIMESTAMP_ADD(`c`.`StartTime`, INTERVAL CAST(1.0 AS INT64) HOUR)" +
+                $"{Environment.NewLine}FROM `Concerts` AS `c`{Environment.NewLine}" +
+                $"WHERE `c`.`SingerId` = @__singerId_0";
             _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateResultSet(
                 new List<Tuple<V1.TypeCode, string>>
                 {
@@ -1005,7 +1052,9 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
         public async Task CanUseDateTimeAddMinutes()
         {
             using var db = new MockServerSampleDbContext(ConnectionString);
-            var sql = $"SELECT TIMESTAMP_ADD(c.StartTime, INTERVAL CAST(1.0 AS INT64) MINUTE){Environment.NewLine}FROM Concerts AS c{Environment.NewLine}WHERE c.SingerId = @__singerId_0";
+            var sql = $"SELECT TIMESTAMP_ADD(`c`.`StartTime`, INTERVAL CAST(1.0 AS INT64) MINUTE)" +
+                $"{Environment.NewLine}FROM `Concerts` AS `c`{Environment.NewLine}" +
+                $"WHERE `c`.`SingerId` = @__singerId_0";
             _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateResultSet(
                 new List<Tuple<V1.TypeCode, string>>
                 {
@@ -1029,7 +1078,9 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
         public async Task CanUseDateTimeAddSeconds()
         {
             using var db = new MockServerSampleDbContext(ConnectionString);
-            var sql = $"SELECT TIMESTAMP_ADD(c.StartTime, INTERVAL CAST(1.0 AS INT64) SECOND){Environment.NewLine}FROM Concerts AS c{Environment.NewLine}WHERE c.SingerId = @__singerId_0";
+            var sql = $"SELECT TIMESTAMP_ADD(`c`.`StartTime`, INTERVAL CAST(1.0 AS INT64) SECOND)" +
+                $"{Environment.NewLine}FROM `Concerts` AS `c`{Environment.NewLine}" +
+                $"WHERE `c`.`SingerId` = @__singerId_0";
             _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateResultSet(
                 new List<Tuple<V1.TypeCode, string>>
                 {
@@ -1053,7 +1104,9 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
         public async Task CanUseDateTimeAddMilliseconds()
         {
             using var db = new MockServerSampleDbContext(ConnectionString);
-            var sql = $"SELECT TIMESTAMP_ADD(c.StartTime, INTERVAL CAST(1.0 AS INT64) MILLISECOND){Environment.NewLine}FROM Concerts AS c{Environment.NewLine}WHERE c.SingerId = @__singerId_0";
+            var sql = $"SELECT TIMESTAMP_ADD(`c`.`StartTime`, INTERVAL CAST(1.0 AS INT64) MILLISECOND)" +
+                $"{Environment.NewLine}FROM `Concerts` AS `c`{Environment.NewLine}" +
+                $"WHERE `c`.`SingerId` = @__singerId_0";
             _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateResultSet(
                 new List<Tuple<V1.TypeCode, string>>
                 {
@@ -1077,7 +1130,9 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
         public async Task CanUseDateTimeAddTicks()
         {
             using var db = new MockServerSampleDbContext(ConnectionString);
-            var sql = $"SELECT TIMESTAMP_ADD(c.StartTime, INTERVAL 100 * 1 NANOSECOND){Environment.NewLine}FROM Concerts AS c{Environment.NewLine}WHERE c.SingerId = @__singerId_0";
+            var sql = $"SELECT TIMESTAMP_ADD(`c`.`StartTime`, INTERVAL 100 * 1 NANOSECOND)" +
+                $"{Environment.NewLine}FROM `Concerts` AS `c`{Environment.NewLine}" +
+                $"WHERE `c`.`SingerId` = @__singerId_0";
             _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateResultSet(
                 new List<Tuple<V1.TypeCode, string>>
                 {
@@ -1101,7 +1156,8 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
         public async Task CanUseLongAbs()
         {
             using var db = new MockServerSampleDbContext(ConnectionString);
-            var sql = $"SELECT ABS(t.ColInt64){Environment.NewLine}FROM TableWithAllColumnTypes AS t{Environment.NewLine}WHERE t.ColInt64 = @__id_0{Environment.NewLine}LIMIT 1";
+            var sql = $"SELECT ABS(`t`.`ColInt64`){Environment.NewLine}FROM `TableWithAllColumnTypes` AS `t`" +
+                $"{Environment.NewLine}WHERE `t`.`ColInt64` = @__id_0{Environment.NewLine}LIMIT 1";
             _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateResultSet(
                 new List<Tuple<V1.TypeCode, string>>
                 {
@@ -1125,7 +1181,8 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
         public async Task CanUseDoubleAbs()
         {
             using var db = new MockServerSampleDbContext(ConnectionString);
-            var sql = $"SELECT ABS(COALESCE(t.ColFloat64, 0.0)){Environment.NewLine}FROM TableWithAllColumnTypes AS t{Environment.NewLine}WHERE t.ColInt64 = @__id_0{Environment.NewLine}LIMIT 1";
+            var sql = $"SELECT ABS(COALESCE(`t`.`ColFloat64`, 0.0)){Environment.NewLine}FROM `TableWithAllColumnTypes` AS `t`" +
+                $"{Environment.NewLine}WHERE `t`.`ColInt64` = @__id_0{Environment.NewLine}LIMIT 1";
             _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateResultSet(
                 new List<Tuple<V1.TypeCode, string>>
                 {
@@ -1149,7 +1206,8 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
         public async Task CanUseDecimalAbs()
         {
             using var db = new MockServerSampleDbContext(ConnectionString);
-            var sql = $"SELECT ABS(COALESCE(t.ColNumeric, 0)){Environment.NewLine}FROM TableWithAllColumnTypes AS t{Environment.NewLine}WHERE t.ColInt64 = @__id_0{Environment.NewLine}LIMIT 1";
+            var sql = $"SELECT ABS(COALESCE(`t`.`ColNumeric`, 0)){Environment.NewLine}FROM `TableWithAllColumnTypes` AS `t`" +
+                $"{Environment.NewLine}WHERE `t`.`ColInt64` = @__id_0{Environment.NewLine}LIMIT 1";
             _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateResultSet(
                 new List<Tuple<V1.TypeCode, string>>
                 {
@@ -1173,7 +1231,8 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
         public async Task CanUseLongMax()
         {
             using var db = new MockServerSampleDbContext(ConnectionString);
-            var sql = $"SELECT GREATEST(t.ColInt64, 2){Environment.NewLine}FROM TableWithAllColumnTypes AS t{Environment.NewLine}WHERE t.ColInt64 = @__id_0{Environment.NewLine}LIMIT 1";
+            var sql = $"SELECT GREATEST(`t`.`ColInt64`, 2){Environment.NewLine}FROM `TableWithAllColumnTypes` AS `t`" +
+                $"{Environment.NewLine}WHERE `t`.`ColInt64` = @__id_0{Environment.NewLine}LIMIT 1";
             _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateResultSet(
                 new List<Tuple<V1.TypeCode, string>>
                 {
@@ -1197,7 +1256,9 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
         public async Task CanUseDoubleMax()
         {
             using var db = new MockServerSampleDbContext(ConnectionString);
-            var sql = $"SELECT GREATEST(COALESCE(t.ColFloat64, 0.0), 3.1400000000000001){Environment.NewLine}FROM TableWithAllColumnTypes AS t{Environment.NewLine}WHERE t.ColInt64 = @__id_0{Environment.NewLine}LIMIT 1";
+            var sql = $"SELECT GREATEST(COALESCE(`t`.`ColFloat64`, 0.0), 3.1400000000000001)" +
+                $"{Environment.NewLine}FROM `TableWithAllColumnTypes` AS `t`{Environment.NewLine}" +
+                $"WHERE `t`.`ColInt64` = @__id_0{Environment.NewLine}LIMIT 1";
             _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateResultSet(
                 new List<Tuple<V1.TypeCode, string>>
                 {
@@ -1221,7 +1282,8 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
         public async Task CanUseLongMin()
         {
             using var db = new MockServerSampleDbContext(ConnectionString);
-            var sql = $"SELECT LEAST(t.ColInt64, 2){Environment.NewLine}FROM TableWithAllColumnTypes AS t{Environment.NewLine}WHERE t.ColInt64 = @__id_0{Environment.NewLine}LIMIT 1";
+            var sql = $"SELECT LEAST(`t`.`ColInt64`, 2){Environment.NewLine}FROM `TableWithAllColumnTypes` AS `t`" +
+                $"{Environment.NewLine}WHERE `t`.`ColInt64` = @__id_0{Environment.NewLine}LIMIT 1";
             _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateResultSet(
                 new List<Tuple<V1.TypeCode, string>>
                 {
@@ -1245,7 +1307,9 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
         public async Task CanUseDoubleMin()
         {
             using var db = new MockServerSampleDbContext(ConnectionString);
-            var sql = $"SELECT LEAST(COALESCE(t.ColFloat64, 0.0), 3.1400000000000001){Environment.NewLine}FROM TableWithAllColumnTypes AS t{Environment.NewLine}WHERE t.ColInt64 = @__id_0{Environment.NewLine}LIMIT 1";
+            var sql = $"SELECT LEAST(COALESCE(`t`.`ColFloat64`, 0.0), 3.1400000000000001)" +
+                $"{Environment.NewLine}FROM `TableWithAllColumnTypes` AS `t`{Environment.NewLine}" +
+                $"WHERE `t`.`ColInt64` = @__id_0{Environment.NewLine}LIMIT 1";
             _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateResultSet(
                 new List<Tuple<V1.TypeCode, string>>
                 {
@@ -1269,7 +1333,8 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
         public async Task CanUseRound()
         {
             using var db = new MockServerSampleDbContext(ConnectionString);
-            var sql = $"SELECT ROUND(COALESCE(t.ColFloat64, 0.0)){Environment.NewLine}FROM TableWithAllColumnTypes AS t{Environment.NewLine}WHERE t.ColInt64 = @__id_0{Environment.NewLine}LIMIT 1";
+            var sql = $"SELECT ROUND(COALESCE(`t`.`ColFloat64`, 0.0)){Environment.NewLine}FROM `TableWithAllColumnTypes` AS `t`" +
+                $"{Environment.NewLine}WHERE `t`.`ColInt64` = @__id_0{Environment.NewLine}LIMIT 1";
             _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateResultSet(
                 new List<Tuple<V1.TypeCode, string>>
                 {
@@ -1293,7 +1358,8 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
         public async Task CanUseDecimalRound()
         {
             using var db = new MockServerSampleDbContext(ConnectionString);
-            var sql = $"SELECT ROUND(COALESCE(t.ColNumeric, 0)){Environment.NewLine}FROM TableWithAllColumnTypes AS t{Environment.NewLine}WHERE t.ColInt64 = @__id_0{Environment.NewLine}LIMIT 1";
+            var sql = $"SELECT ROUND(COALESCE(`t`.`ColNumeric`, 0)){Environment.NewLine}FROM `TableWithAllColumnTypes` AS `t`" +
+                $"{Environment.NewLine}WHERE `t`.`ColInt64` = @__id_0{Environment.NewLine}LIMIT 1";
             _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateResultSet(
                 new List<Tuple<V1.TypeCode, string>>
                 {
@@ -1317,7 +1383,8 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
         public async Task CanUseRoundWithDigits()
         {
             using var db = new MockServerSampleDbContext(ConnectionString);
-            var sql = $"SELECT ROUND(COALESCE(t.ColFloat64, 0.0), 1){Environment.NewLine}FROM TableWithAllColumnTypes AS t{Environment.NewLine}WHERE t.ColInt64 = @__id_0{Environment.NewLine}LIMIT 1";
+            var sql = $"SELECT ROUND(COALESCE(`t`.`ColFloat64`, 0.0), 1){Environment.NewLine}FROM `TableWithAllColumnTypes` AS `t`" +
+                $"{Environment.NewLine}WHERE `t`.`ColInt64` = @__id_0{Environment.NewLine}LIMIT 1";
             _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateResultSet(
                 new List<Tuple<V1.TypeCode, string>>
                 {
@@ -1341,7 +1408,8 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
         public async Task CanUseCeiling()
         {
             using var db = new MockServerSampleDbContext(ConnectionString);
-            var sql = $"SELECT CEIL(COALESCE(t.ColFloat64, 0.0)){Environment.NewLine}FROM TableWithAllColumnTypes AS t{Environment.NewLine}WHERE t.ColInt64 = @__id_0{Environment.NewLine}LIMIT 1";
+            var sql = $"SELECT CEIL(COALESCE(`t`.`ColFloat64`, 0.0)){Environment.NewLine}FROM `TableWithAllColumnTypes` AS `t`" +
+                $"{Environment.NewLine}WHERE `t`.`ColInt64` = @__id_0{Environment.NewLine}LIMIT 1";
             _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateResultSet(
                 new List<Tuple<V1.TypeCode, string>>
                 {
@@ -1365,7 +1433,8 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
         public async Task CanUseFloor()
         {
             using var db = new MockServerSampleDbContext(ConnectionString);
-            var sql = $"SELECT FLOOR(COALESCE(t.ColFloat64, 0.0)){Environment.NewLine}FROM TableWithAllColumnTypes AS t{Environment.NewLine}WHERE t.ColInt64 = @__id_0{Environment.NewLine}LIMIT 1";
+            var sql = $"SELECT FLOOR(COALESCE(`t`.`ColFloat64`, 0.0)){Environment.NewLine}FROM `TableWithAllColumnTypes` AS `t`" +
+                $"{Environment.NewLine}WHERE `t`.`ColInt64` = @__id_0{Environment.NewLine}LIMIT 1";
             _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateResultSet(
                 new List<Tuple<V1.TypeCode, string>>
                 {
@@ -1389,7 +1458,10 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
         public async Task CanUseDateTimeProperties()
         {
             using var db = new MockServerSampleDbContext(ConnectionString);
-            var sql = $"SELECT EXTRACT(YEAR FROM COALESCE(t.ColTimestamp, TIMESTAMP '0001-01-01T00:00:00Z') AT TIME ZONE 'UTC') AS Year, EXTRACT(MONTH FROM COALESCE(t.ColTimestamp, TIMESTAMP '0001-01-01T00:00:00Z') AT TIME ZONE 'UTC') AS Month{Environment.NewLine}FROM TableWithAllColumnTypes AS t{Environment.NewLine}WHERE t.ColInt64 = @__id_0{Environment.NewLine}LIMIT 1";
+            var sql = $"SELECT EXTRACT(YEAR FROM COALESCE(`t`.`ColTimestamp`, TIMESTAMP '0001-01-01T00:00:00Z') AT TIME ZONE 'UTC') AS `Year`, " +
+                $"EXTRACT(MONTH FROM COALESCE(`t`.`ColTimestamp`, TIMESTAMP '0001-01-01T00:00:00Z') AT TIME ZONE 'UTC') AS `Month`" +
+                $"{Environment.NewLine}FROM `TableWithAllColumnTypes` AS `t`" +
+                $"{Environment.NewLine}WHERE `t`.`ColInt64` = @__id_0{Environment.NewLine}LIMIT 1";
             _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateResultSet(
                 new List<Tuple<V1.TypeCode, string>>
                 {
@@ -1420,7 +1492,13 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
         public async Task CanUseSpannerDateProperties()
         {
             using var db = new MockServerSampleDbContext(ConnectionString);
-            var sql = $"SELECT EXTRACT(YEAR FROM COALESCE(t.ColDate, DATE '0001-01-01')) AS Year, EXTRACT(MONTH FROM COALESCE(t.ColDate, DATE '0001-01-01')) AS Month, EXTRACT(DAY FROM COALESCE(t.ColDate, DATE '0001-01-01')) AS Day, EXTRACT(DAYOFYEAR FROM COALESCE(t.ColDate, DATE '0001-01-01')) AS DayOfYear, EXTRACT(DAYOFWEEK FROM COALESCE(t.ColDate, DATE '0001-01-01')) - 1 AS DayOfWeek{Environment.NewLine}FROM TableWithAllColumnTypes AS t{Environment.NewLine}WHERE t.ColInt64 = @__id_0{Environment.NewLine}LIMIT 1";
+            var sql = $"SELECT EXTRACT(YEAR FROM COALESCE(`t`.`ColDate`, DATE '0001-01-01')) AS `Year`, " +
+                "EXTRACT(MONTH FROM COALESCE(`t`.`ColDate`, DATE '0001-01-01')) AS `Month`, " +
+                "EXTRACT(DAY FROM COALESCE(`t`.`ColDate`, DATE '0001-01-01')) AS `Day`, " +
+                "EXTRACT(DAYOFYEAR FROM COALESCE(`t`.`ColDate`, DATE '0001-01-01')) AS `DayOfYear`, " +
+                "EXTRACT(DAYOFWEEK FROM COALESCE(`t`.`ColDate`, DATE '0001-01-01')) - 1 AS `DayOfWeek`" +
+                $"{Environment.NewLine}FROM `TableWithAllColumnTypes` AS `t`{Environment.NewLine}" +
+                $"WHERE `t`.`ColInt64` = @__id_0{Environment.NewLine}LIMIT 1";
             _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateResultSet(
                 new List<Tuple<V1.TypeCode, string>>
                 {
@@ -1463,7 +1541,9 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
         public async Task CanUseBoolToString()
         {
             using var db = new MockServerSampleDbContext(ConnectionString);
-            var sql = $"SELECT CAST(COALESCE(t.ColBool, false) AS STRING){Environment.NewLine}FROM TableWithAllColumnTypes AS t{Environment.NewLine}WHERE t.ColInt64 = @__id_0{Environment.NewLine}LIMIT 1";
+            var sql = $"SELECT CAST(COALESCE(`t`.`ColBool`, false) AS STRING)" +
+                $"{Environment.NewLine}FROM `TableWithAllColumnTypes` AS `t`{Environment.NewLine}" +
+                $"WHERE `t`.`ColInt64` = @__id_0{Environment.NewLine}LIMIT 1";
             _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateResultSet(
                 new List<Tuple<V1.TypeCode, string>>
                 {
@@ -1486,7 +1566,8 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
         public async Task CanUseBytesToString()
         {
             using var db = new MockServerSampleDbContext(ConnectionString);
-            var sql = $"SELECT CAST(t.ColBytes AS STRING){Environment.NewLine}FROM TableWithAllColumnTypes AS t{Environment.NewLine}WHERE t.ColInt64 = @__id_0{Environment.NewLine}LIMIT 1";
+            var sql = $"SELECT CAST(`t`.`ColBytes` AS STRING){Environment.NewLine}FROM `TableWithAllColumnTypes` AS `t`" +
+                $"{Environment.NewLine}WHERE `t`.`ColInt64` = @__id_0{Environment.NewLine}LIMIT 1";
             _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateResultSet(
                 new List<Tuple<V1.TypeCode, string>>
                 {
@@ -1510,7 +1591,8 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
         public async Task CanUseLongToString()
         {
             using var db = new MockServerSampleDbContext(ConnectionString);
-            var sql = $"SELECT CAST(t.ColInt64 AS STRING){Environment.NewLine}FROM TableWithAllColumnTypes AS t{Environment.NewLine}WHERE t.ColInt64 = @__id_0{Environment.NewLine}LIMIT 1";
+            var sql = $"SELECT CAST(`t`.`ColInt64` AS STRING){Environment.NewLine}FROM `TableWithAllColumnTypes` AS `t`" +
+                $"{Environment.NewLine}WHERE `t`.`ColInt64` = @__id_0{Environment.NewLine}LIMIT 1";
             _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateResultSet(
                 new List<Tuple<V1.TypeCode, string>>
                 {
@@ -1534,7 +1616,8 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
         public async Task CanUseSpannerNumericToString()
         {
             using var db = new MockServerSampleDbContext(ConnectionString);
-            var sql = $"SELECT CAST(COALESCE(t.ColNumeric, 0) AS STRING){Environment.NewLine}FROM TableWithAllColumnTypes AS t{Environment.NewLine}WHERE t.ColInt64 = @__id_0{Environment.NewLine}LIMIT 1";
+            var sql = $"SELECT CAST(COALESCE(`t`.`ColNumeric`, 0) AS STRING){Environment.NewLine}FROM `TableWithAllColumnTypes` AS `t`" +
+                $"{Environment.NewLine}WHERE `t`.`ColInt64` = @__id_0{Environment.NewLine}LIMIT 1";
             _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateResultSet(
                 new List<Tuple<V1.TypeCode, string>>
                 {
@@ -1558,7 +1641,8 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
         public async Task CanUseDoubleToString()
         {
             using var db = new MockServerSampleDbContext(ConnectionString);
-            var sql = $"SELECT CAST(COALESCE(t.ColFloat64, 0.0) AS STRING){Environment.NewLine}FROM TableWithAllColumnTypes AS t{Environment.NewLine}WHERE t.ColInt64 = @__id_0{Environment.NewLine}LIMIT 1";
+            var sql = $"SELECT CAST(COALESCE(`t`.`ColFloat64`, 0.0) AS STRING){Environment.NewLine}FROM `TableWithAllColumnTypes` AS `t`" +
+                $"{Environment.NewLine}WHERE `t`.`ColInt64` = @__id_0{Environment.NewLine}LIMIT 1";
             _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateResultSet(
                 new List<Tuple<V1.TypeCode, string>>
                 {
@@ -1582,7 +1666,9 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
         public async Task CanUseSpannerDateToString()
         {
             using var db = new MockServerSampleDbContext(ConnectionString);
-            var sql = $"SELECT CAST(COALESCE(t.ColDate, DATE '0001-01-01') AS STRING){Environment.NewLine}FROM TableWithAllColumnTypes AS t{Environment.NewLine}WHERE t.ColInt64 = @__id_0{Environment.NewLine}LIMIT 1";
+            var sql = $"SELECT CAST(COALESCE(`t`.`ColDate`, DATE '0001-01-01') AS STRING)" +
+                $"{Environment.NewLine}FROM `TableWithAllColumnTypes` AS `t`{Environment.NewLine}WHERE `t`.`ColInt64` = @__id_0" +
+                $"{Environment.NewLine}LIMIT 1";
             _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateResultSet(
                 new List<Tuple<V1.TypeCode, string>>
                 {
@@ -1606,7 +1692,9 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
         public async Task CanUseDateTimeToString()
         {
             using var db = new MockServerSampleDbContext(ConnectionString);
-            var sql = $"SELECT FORMAT_TIMESTAMP('%FT%H:%M:%E*SZ', COALESCE(t.ColTimestamp, TIMESTAMP '0001-01-01T00:00:00Z'), 'UTC'){Environment.NewLine}FROM TableWithAllColumnTypes AS t{Environment.NewLine}WHERE t.ColInt64 = @__id_0{Environment.NewLine}LIMIT 1";
+            var sql = $"SELECT FORMAT_TIMESTAMP('%FT%H:%M:%E*SZ', COALESCE(`t`.`ColTimestamp`, TIMESTAMP '0001-01-01T00:00:00Z'), 'UTC')" +
+                $"{Environment.NewLine}FROM `TableWithAllColumnTypes` AS `t`{Environment.NewLine}WHERE `t`.`ColInt64` = @__id_0" +
+                $"{Environment.NewLine}LIMIT 1";
             _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateResultSet(
                 new List<Tuple<V1.TypeCode, string>>
                 {
@@ -1630,7 +1718,8 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
         public async Task CanUseLongListCount()
         {
             using var db = new MockServerSampleDbContext(ConnectionString);
-            var sql = $"SELECT t.ColInt64{Environment.NewLine}FROM TableWithAllColumnTypes AS t{Environment.NewLine}WHERE ARRAY_LENGTH(t.ColInt64Array) = 2{Environment.NewLine}LIMIT 1";
+            var sql = $"SELECT `t`.`ColInt64`{Environment.NewLine}FROM `TableWithAllColumnTypes` AS `t`" +
+                $"{Environment.NewLine}WHERE ARRAY_LENGTH(`t`.`ColInt64Array`) = 2{Environment.NewLine}LIMIT 1";
             _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateSelect1ResultSet());
 
             var id = await db.TableWithAllColumnTypes
@@ -1644,7 +1733,8 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
         public async Task CanUseDoubleListCount()
         {
             using var db = new MockServerSampleDbContext(ConnectionString);
-            var sql = $"SELECT t.ColInt64{Environment.NewLine}FROM TableWithAllColumnTypes AS t{Environment.NewLine}WHERE ARRAY_LENGTH(t.ColFloat64Array) = 2{Environment.NewLine}LIMIT 1";
+            var sql = $"SELECT `t`.`ColInt64`{Environment.NewLine}FROM `TableWithAllColumnTypes` AS `t`" +
+                $"{Environment.NewLine}WHERE ARRAY_LENGTH(`t`.`ColFloat64Array`) = 2{Environment.NewLine}LIMIT 1";
             _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateSelect1ResultSet());
 
             var id = await db.TableWithAllColumnTypes
@@ -1658,7 +1748,8 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
         public async Task CanUseSpannerNumericListCount()
         {
             using var db = new MockServerSampleDbContext(ConnectionString);
-            var sql = $"SELECT t.ColInt64{Environment.NewLine}FROM TableWithAllColumnTypes AS t{Environment.NewLine}WHERE ARRAY_LENGTH(t.ColNumericArray) = 2{Environment.NewLine}LIMIT 1";
+            var sql = $"SELECT `t`.`ColInt64`{Environment.NewLine}FROM `TableWithAllColumnTypes` AS `t`" +
+                $"{Environment.NewLine}WHERE ARRAY_LENGTH(`t`.`ColNumericArray`) = 2{Environment.NewLine}LIMIT 1";
             _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateSelect1ResultSet());
 
             var id = await db.TableWithAllColumnTypes
@@ -1672,7 +1763,8 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
         public async Task CanUseBoolListCount()
         {
             using var db = new MockServerSampleDbContext(ConnectionString);
-            var sql = $"SELECT t.ColInt64{Environment.NewLine}FROM TableWithAllColumnTypes AS t{Environment.NewLine}WHERE ARRAY_LENGTH(t.ColBoolArray) = 2{Environment.NewLine}LIMIT 1";
+            var sql = $"SELECT `t`.`ColInt64`{Environment.NewLine}FROM `TableWithAllColumnTypes` AS `t`" +
+                $"{Environment.NewLine}WHERE ARRAY_LENGTH(`t`.`ColBoolArray`) = 2{Environment.NewLine}LIMIT 1";
             _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateSelect1ResultSet());
 
             var id = await db.TableWithAllColumnTypes
@@ -1686,7 +1778,8 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
         public async Task CanUseStringListCount()
         {
             using var db = new MockServerSampleDbContext(ConnectionString);
-            var sql = $"SELECT t.ColInt64{Environment.NewLine}FROM TableWithAllColumnTypes AS t{Environment.NewLine}WHERE ARRAY_LENGTH(t.ColStringArray) = 2{Environment.NewLine}LIMIT 1";
+            var sql = $"SELECT `t`.`ColInt64`{Environment.NewLine}FROM `TableWithAllColumnTypes` AS `t`" +
+                $"{Environment.NewLine}WHERE ARRAY_LENGTH(`t`.`ColStringArray`) = 2{Environment.NewLine}LIMIT 1";
             _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateSelect1ResultSet());
 
             var id = await db.TableWithAllColumnTypes
@@ -1700,7 +1793,8 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
         public async Task CanUseSByteArrayListCount()
         {
             using var db = new MockServerSampleDbContext(ConnectionString);
-            var sql = $"SELECT t.ColInt64{Environment.NewLine}FROM TableWithAllColumnTypes AS t{Environment.NewLine}WHERE ARRAY_LENGTH(t.ColBytesArray) = 2{Environment.NewLine}LIMIT 1";
+            var sql = $"SELECT `t`.`ColInt64`{Environment.NewLine}FROM `TableWithAllColumnTypes` AS `t`" +
+                $"{Environment.NewLine}WHERE ARRAY_LENGTH(`t`.`ColBytesArray`) = 2{Environment.NewLine}LIMIT 1";
             _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateSelect1ResultSet());
 
             var id = await db.TableWithAllColumnTypes
@@ -1714,7 +1808,8 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
         public async Task CanUseSpannerDateListCount()
         {
             using var db = new MockServerSampleDbContext(ConnectionString);
-            var sql = $"SELECT t.ColInt64{Environment.NewLine}FROM TableWithAllColumnTypes AS t{Environment.NewLine}WHERE ARRAY_LENGTH(t.ColDateArray) = 2{Environment.NewLine}LIMIT 1";
+            var sql = $"SELECT `t`.`ColInt64`{Environment.NewLine}FROM `TableWithAllColumnTypes` AS `t`" +
+                $"{Environment.NewLine}WHERE ARRAY_LENGTH(`t`.`ColDateArray`) = 2{Environment.NewLine}LIMIT 1";
             _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateSelect1ResultSet());
 
             var id = await db.TableWithAllColumnTypes
@@ -1728,7 +1823,8 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
         public async Task CanUseDateTimeListCount()
         {
             using var db = new MockServerSampleDbContext(ConnectionString);
-            var sql = $"SELECT t.ColInt64{Environment.NewLine}FROM TableWithAllColumnTypes AS t{Environment.NewLine}WHERE ARRAY_LENGTH(t.ColTimestampArray) = 2{Environment.NewLine}LIMIT 1";
+            var sql = $"SELECT `t`.`ColInt64`{Environment.NewLine}FROM `TableWithAllColumnTypes` AS `t`" +
+                $"{Environment.NewLine}WHERE ARRAY_LENGTH(`t`.`ColTimestampArray`) = 2{Environment.NewLine}LIMIT 1";
             _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateSelect1ResultSet());
 
             var id = await db.TableWithAllColumnTypes
@@ -1742,9 +1838,10 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
         public async Task CanInsertCommitTimestamp()
         {
             using var db = new MockServerSampleDbContext(ConnectionString);
-            var sql = $"INSERT INTO TableWithAllColumnTypes (ColCommitTS, ColInt64, ColBool, ColBoolArray, ColBytes, ColBytesArray, ColBytesMax, ColBytesMaxArray, ColDate, ColDateArray, ColFloat64, ColFloat64Array, ColInt64Array, ColNumeric, ColNumericArray, ColString, ColStringArray, ColStringMax, ColStringMaxArray, ColTimestamp, ColTimestampArray){Environment.NewLine}VALUES (PENDING_COMMIT_TIMESTAMP(), @p0, @p1, @p2, @p3, @p4, @p5, @p6, @p7, @p8, @p9, @p10, @p11, @p12, @p13, @p14, @p15, @p16, @p17, @p18, @p19)";
+            var sql = $"INSERT INTO `TableWithAllColumnTypes` (`ColCommitTS`, `ColInt64`, `ColBool`, `ColBoolArray`, `ColBytes`, `ColBytesArray`, `ColBytesMax`, `ColBytesMaxArray`, `ColDate`, `ColDateArray`, `ColFloat64`, `ColFloat64Array`, `ColInt64Array`, `ColNumeric`, `ColNumericArray`, `ColString`, `ColStringArray`, `ColStringMax`, `ColStringMaxArray`, `ColTimestamp`, `ColTimestampArray`){Environment.NewLine}VALUES (PENDING_COMMIT_TIMESTAMP(), @p0, @p1, @p2, @p3, @p4, @p5, @p6, @p7, @p8, @p9, @p10, @p11, @p12, @p13, @p14, @p15, @p16, @p17, @p18, @p19)";
             _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateUpdateCount(1L));
-            _fixture.SpannerMock.AddOrUpdateStatementResult($"{Environment.NewLine}SELECT ColComputed{Environment.NewLine}FROM TableWithAllColumnTypes{Environment.NewLine}WHERE  TRUE  AND ColInt64 = @p0", StatementResult.CreateSingleColumnResultSet(new V1.Type { Code = V1.TypeCode.String }, "FOO"));
+            _fixture.SpannerMock.AddOrUpdateStatementResult($"{Environment.NewLine}SELECT `ColComputed`" +
+                $"{Environment.NewLine}FROM `TableWithAllColumnTypes`{Environment.NewLine}WHERE  TRUE  AND `ColInt64` = @p0", StatementResult.CreateSingleColumnResultSet(new V1.Type { Code = V1.TypeCode.String }, "FOO"));
 
             db.TableWithAllColumnTypes.Add(new TableWithAllColumnTypes { ColInt64 = 1L });
             await db.SaveChangesAsync();
@@ -1763,9 +1860,10 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
         public async Task CanUpdateCommitTimestamp()
         {
             using var db = new MockServerSampleDbContext(ConnectionString);
-            var sql = $"UPDATE TableWithAllColumnTypes SET ColCommitTS = PENDING_COMMIT_TIMESTAMP(), ColBool = @p0{Environment.NewLine}WHERE ColInt64 = @p1";
+            var sql = $"UPDATE `TableWithAllColumnTypes` SET `ColCommitTS` = PENDING_COMMIT_TIMESTAMP(), `ColBool` = @p0" +
+                $"{Environment.NewLine}WHERE `ColInt64` = @p1";
             _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateUpdateCount(1L));
-            _fixture.SpannerMock.AddOrUpdateStatementResult($"{Environment.NewLine}SELECT ColComputed{Environment.NewLine}FROM TableWithAllColumnTypes{Environment.NewLine}WHERE  TRUE  AND ColInt64 = @p1", StatementResult.CreateSingleColumnResultSet(new V1.Type { Code = V1.TypeCode.String }, "FOO"));
+            _fixture.SpannerMock.AddOrUpdateStatementResult($"{Environment.NewLine}SELECT `ColComputed`{Environment.NewLine}FROM `TableWithAllColumnTypes`{Environment.NewLine}WHERE  TRUE  AND `ColInt64` = @p1", StatementResult.CreateSingleColumnResultSet(new V1.Type { Code = V1.TypeCode.String }, "FOO"));
 
             var row = new TableWithAllColumnTypes { ColInt64 = 1L };
             db.TableWithAllColumnTypes.Attach(row);
@@ -1786,7 +1884,8 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
         public async Task CanUseAsAsyncEnumerable()
         {
             using var db = new MockServerSampleDbContext(ConnectionString);
-            var sql = $"SELECT s.SingerId, s.BirthDate, s.FirstName, s.FullName, s.LastName, s.Picture{Environment.NewLine}FROM Singers AS s{Environment.NewLine}WHERE STRPOS(s.FirstName, @__firstName_0) > 0";
+            var sql = $"SELECT `s`.`SingerId`, `s`.`BirthDate`, `s`.`FirstName`, `s`.`FullName`, `s`.`LastName`, `s`.`Picture`" +
+                $"{Environment.NewLine}FROM `Singers` AS `s`{Environment.NewLine}WHERE STRPOS(`s`.`FirstName`, @__firstName_0) > 0";
             AddFindSingerResult(sql);
 
             var firstName = "Alice";
@@ -1811,9 +1910,14 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
         public async Task CanInsertRowWithCommitTimestampAndComputedColumn()
         {
             using var db = new MockServerSampleDbContext(ConnectionString);
-            var sql = $"INSERT INTO TableWithAllColumnTypes (ColCommitTS, ColInt64, ColBool, ColBoolArray, ColBytes, ColBytesArray, ColBytesMax, ColBytesMaxArray, ColDate, ColDateArray, ColFloat64, ColFloat64Array, ColInt64Array, ColNumeric, ColNumericArray, ColString, ColStringArray, ColStringMax, ColStringMaxArray, ColTimestamp, ColTimestampArray){Environment.NewLine}VALUES (PENDING_COMMIT_TIMESTAMP(), @p0, @p1, @p2, @p3, @p4, @p5, @p6, @p7, @p8, @p9, @p10, @p11, @p12, @p13, @p14, @p15, @p16, @p17, @p18, @p19)";
+            var sql = $"INSERT INTO `TableWithAllColumnTypes` (`ColCommitTS`, `ColInt64`, `ColBool`, `ColBoolArray`, " +
+                $"`ColBytes`, `ColBytesArray`, `ColBytesMax`, `ColBytesMaxArray`, `ColDate`, `ColDateArray`, `ColFloat64`, " +
+                $"`ColFloat64Array`, `ColInt64Array`, `ColNumeric`, `ColNumericArray`, `ColString`, `ColStringArray`, " +
+                $"`ColStringMax`, `ColStringMaxArray`, `ColTimestamp`, `ColTimestampArray`)" +
+                $"{Environment.NewLine}VALUES " +
+                $"(PENDING_COMMIT_TIMESTAMP(), @p0, @p1, @p2, @p3, @p4, @p5, @p6, @p7, @p8, @p9, @p10, @p11, @p12, @p13, @p14, @p15, @p16, @p17, @p18, @p19)";
             _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateUpdateCount(1L));
-            var selectSql = $"{Environment.NewLine}SELECT ColComputed{Environment.NewLine}FROM TableWithAllColumnTypes{Environment.NewLine}WHERE  TRUE  AND ColInt64 = @p0";
+            var selectSql = $"{Environment.NewLine}SELECT `ColComputed`{Environment.NewLine}FROM `TableWithAllColumnTypes`{Environment.NewLine}WHERE  TRUE  AND `ColInt64` = @p0";
             _fixture.SpannerMock.AddOrUpdateStatementResult(selectSql, StatementResult.CreateSingleColumnResultSet(new V1.Type { Code = V1.TypeCode.String }, "FOO"));
 
             db.TableWithAllColumnTypes.Add(
@@ -1861,7 +1965,8 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
 
         private string AddSelectSingerFullNameResult(string fullName, int paramIndex)
         {
-            var selectFullNameSql = $"{Environment.NewLine}SELECT FullName{Environment.NewLine}FROM Singers{Environment.NewLine}WHERE  TRUE  AND SingerId = @p{paramIndex}";
+            var selectFullNameSql = $"{Environment.NewLine}SELECT `FullName`{Environment.NewLine}FROM `Singers`" +
+                $"{Environment.NewLine}WHERE  TRUE  AND `SingerId` = @p{paramIndex}";
             _fixture.SpannerMock.AddOrUpdateStatementResult(selectFullNameSql, StatementResult.CreateResultSet(
                 new List<Tuple<V1.TypeCode, string>>
                 {

--- a/Google.Cloud.EntityFrameworkCore.Spanner.Tests/EntityFrameworkMockServerTests.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.Tests/EntityFrameworkMockServerTests.cs
@@ -1838,7 +1838,12 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
         public async Task CanInsertCommitTimestamp()
         {
             using var db = new MockServerSampleDbContext(ConnectionString);
-            var sql = $"INSERT INTO `TableWithAllColumnTypes` (`ColCommitTS`, `ColInt64`, `ColBool`, `ColBoolArray`, `ColBytes`, `ColBytesArray`, `ColBytesMax`, `ColBytesMaxArray`, `ColDate`, `ColDateArray`, `ColFloat64`, `ColFloat64Array`, `ColInt64Array`, `ColNumeric`, `ColNumericArray`, `ColString`, `ColStringArray`, `ColStringMax`, `ColStringMaxArray`, `ColTimestamp`, `ColTimestampArray`){Environment.NewLine}VALUES (PENDING_COMMIT_TIMESTAMP(), @p0, @p1, @p2, @p3, @p4, @p5, @p6, @p7, @p8, @p9, @p10, @p11, @p12, @p13, @p14, @p15, @p16, @p17, @p18, @p19)";
+            var sql = "INSERT INTO `TableWithAllColumnTypes` (`ColCommitTS`, `ColInt64`, `ASC`, `ColBool`, " +
+                "`ColBoolArray`, `ColBytes`, `ColBytesArray`, `ColBytesMax`, `ColBytesMaxArray`, `ColDate`, `ColDateArray`," +
+                " `ColFloat64`, `ColFloat64Array`, `ColInt64Array`, `ColNumeric`, `ColNumericArray`, `ColString`, " +
+                "`ColStringArray`, `ColStringMax`, `ColStringMaxArray`, `ColTimestamp`, `ColTimestampArray`)" +
+                $"{Environment.NewLine}VALUES (PENDING_COMMIT_TIMESTAMP(), " +
+                "@p0, @p1, @p2, @p3, @p4, @p5, @p6, @p7, @p8, @p9, @p10, @p11, @p12, @p13, @p14, @p15, @p16, @p17, @p18, @p19, @p20)";
             _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateUpdateCount(1L));
             _fixture.SpannerMock.AddOrUpdateStatementResult($"{Environment.NewLine}SELECT `ColComputed`" +
                 $"{Environment.NewLine}FROM `TableWithAllColumnTypes`{Environment.NewLine}WHERE  TRUE  AND `ColInt64` = @p0", StatementResult.CreateSingleColumnResultSet(new V1.Type { Code = V1.TypeCode.String }, "FOO"));
@@ -1910,12 +1915,11 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
         public async Task CanInsertRowWithCommitTimestampAndComputedColumn()
         {
             using var db = new MockServerSampleDbContext(ConnectionString);
-            var sql = $"INSERT INTO `TableWithAllColumnTypes` (`ColCommitTS`, `ColInt64`, `ColBool`, `ColBoolArray`, " +
-                $"`ColBytes`, `ColBytesArray`, `ColBytesMax`, `ColBytesMaxArray`, `ColDate`, `ColDateArray`, `ColFloat64`, " +
-                $"`ColFloat64Array`, `ColInt64Array`, `ColNumeric`, `ColNumericArray`, `ColString`, `ColStringArray`, " +
-                $"`ColStringMax`, `ColStringMaxArray`, `ColTimestamp`, `ColTimestampArray`)" +
-                $"{Environment.NewLine}VALUES " +
-                $"(PENDING_COMMIT_TIMESTAMP(), @p0, @p1, @p2, @p3, @p4, @p5, @p6, @p7, @p8, @p9, @p10, @p11, @p12, @p13, @p14, @p15, @p16, @p17, @p18, @p19)";
+            var sql = "INSERT INTO `TableWithAllColumnTypes` (`ColCommitTS`, `ColInt64`, `ASC`, `ColBool`, `ColBoolArray`," +
+                " `ColBytes`, `ColBytesArray`, `ColBytesMax`, `ColBytesMaxArray`, `ColDate`, `ColDateArray`, `ColFloat64`," +
+                " `ColFloat64Array`, `ColInt64Array`, `ColNumeric`, `ColNumericArray`, `ColString`, `ColStringArray`," +
+                $" `ColStringMax`, `ColStringMaxArray`, `ColTimestamp`, `ColTimestampArray`){Environment.NewLine}" +
+                "VALUES (PENDING_COMMIT_TIMESTAMP(), @p0, @p1, @p2, @p3, @p4, @p5, @p6, @p7, @p8, @p9, @p10, @p11, @p12, @p13, @p14, @p15, @p16, @p17, @p18, @p19, @p20)";
             _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateUpdateCount(1L));
             var selectSql = $"{Environment.NewLine}SELECT `ColComputed`{Environment.NewLine}FROM `TableWithAllColumnTypes`{Environment.NewLine}WHERE  TRUE  AND `ColInt64` = @p0";
             _fixture.SpannerMock.AddOrUpdateStatementResult(selectSql, StatementResult.CreateSingleColumnResultSet(new V1.Type { Code = V1.TypeCode.String }, "FOO"));

--- a/Google.Cloud.EntityFrameworkCore.Spanner.Tests/MigrationTests/SampleMigrationDataModel.sql
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.Tests/MigrationTests/SampleMigrationDataModel.sql
@@ -1,84 +1,84 @@
-﻿CREATE TABLE Singers (
-    SingerId INT64 NOT NULL,
-    FirstName STRING(200),
-    LastName STRING(200) NOT NULL,
-    FullName STRING(400) NOT NULL AS (COALESCE(FirstName || ' ', '') || LastName) STORED,
-    BirthDate DATE,
-    Picture BYTES(MAX)
-)PRIMARY KEY (SingerId)
-CREATE TABLE TableWithAllColumnTypes (
-    ColInt64 INT64 NOT NULL,
-    ColFloat64 FLOAT64,
-    ColNumeric NUMERIC,
-    ColBool BOOL,
-    ColString STRING(100),
-    ColStringMax STRING(MAX),
-    ColChar STRING(1),
-    ColBytes BYTES(100),
-    ColBytesMax BYTES(MAX),
-    ColDate DATE,
-    ColTimestamp TIMESTAMP,
-    ColCommitTS TIMESTAMP OPTIONS (allow_commit_timestamp=true) ,
-    ColInt64Array ARRAY<INT64>,
-    ColFloat64Array ARRAY<FLOAT64>,
-    ColNumericArray ARRAY<NUMERIC>,
-    ColBoolArray ARRAY<BOOL>,
-    ColStringArray ARRAY<STRING(100)>,
-    ColStringMaxArray ARRAY<STRING(MAX)>,
-    ColBytesArray ARRAY<BYTES(100)>,
-    ColBytesMaxArray ARRAY<BYTES(MAX)>,
-    ColDateArray ARRAY<DATE>,
-    ColTimestampArray ARRAY<TIMESTAMP>,
-    ColGuid STRING(36),
-    ColComputed STRING(MAX) AS (ARRAY_TO_STRING(ColStringArray, ',')) STORED
-)PRIMARY KEY (ColInt64)
-CREATE TABLE Venues (
-    Code STRING(10) NOT NULL,
-    Name STRING(100),
-    Active BOOL NOT NULL,
-    Capacity INT64,
-    Ratings ARRAY<FLOAT64>
-)PRIMARY KEY (Code)
-CREATE TABLE Albums (
-    AlbumId INT64 NOT NULL,
-    Title STRING(100) NOT NULL,
-    ReleaseDate DATE,
-    SingerId INT64 NOT NULL,
-    MarketingBudget INT64,
- CONSTRAINT FK_Albums_Singers FOREIGN KEY (SingerId) REFERENCES Singers (SingerId),
-)PRIMARY KEY (AlbumId)
-CREATE TABLE Concerts (
-    VenueCode STRING(10) NOT NULL,
-    StartTime TIMESTAMP NOT NULL,
-    SingerId INT64 NOT NULL,
-    Title STRING(200),
- CONSTRAINT FK_Concerts_Singers FOREIGN KEY (SingerId) REFERENCES Singers (SingerId),
- CONSTRAINT FK_Concerts_Venues FOREIGN KEY (VenueCode) REFERENCES Venues (Code),
-)PRIMARY KEY (VenueCode, StartTime, SingerId)
-CREATE TABLE Tracks (
-    AlbumId INT64 NOT NULL,
-    TrackId INT64 NOT NULL,
-    Title STRING(200) NOT NULL,
-    Duration NUMERIC,
-    LyricsLanguages ARRAY<STRING(2)>,
-    Lyrics ARRAY<STRING(MAX)>,
-CONSTRAINT Chk_Languages_Lyrics_Length_Equal CHECK (ARRAY_LENGTH(LyricsLanguages) = ARRAY_LENGTH(Lyrics)),
-)PRIMARY KEY (AlbumId, TrackId),
- INTERLEAVE IN PARENT Albums ON DELETE NO ACTION 
+﻿CREATE TABLE `Singers` (
+    `SingerId` INT64 NOT NULL,
+    `FirstName` STRING(200),
+    `LastName` STRING(200) NOT NULL,
+    `FullName` STRING(400) NOT NULL AS (COALESCE(FirstName || ' ', '') || LastName) STORED,
+    `BirthDate` DATE,
+    `Picture` BYTES(MAX)
+)PRIMARY KEY (`SingerId`)
+CREATE TABLE `TableWithAllColumnTypes` (
+    `ColInt64` INT64 NOT NULL,
+    `ColFloat64` FLOAT64,
+    `ColNumeric` NUMERIC,
+    `ColBool` BOOL,
+    `ColString` STRING(100),
+    `ColStringMax` STRING(MAX),
+    `ColChar` STRING(1),
+    `ColBytes` BYTES(100),
+    `ColBytesMax` BYTES(MAX),
+    `ColDate` DATE,
+    `ColTimestamp` TIMESTAMP,
+    `ColCommitTS` TIMESTAMP OPTIONS (allow_commit_timestamp=true) ,
+    `ColInt64Array` ARRAY<INT64>,
+    `ColFloat64Array` ARRAY<FLOAT64>,
+    `ColNumericArray` ARRAY<NUMERIC>,
+    `ColBoolArray` ARRAY<BOOL>,
+    `ColStringArray` ARRAY<STRING(100)>,
+    `ColStringMaxArray` ARRAY<STRING(MAX)>,
+    `ColBytesArray` ARRAY<BYTES(100)>,
+    `ColBytesMaxArray` ARRAY<BYTES(MAX)>,
+    `ColDateArray` ARRAY<DATE>,
+    `ColTimestampArray` ARRAY<TIMESTAMP>,
+    `ColGuid` STRING(36),
+    `ColComputed` STRING(MAX) AS (ARRAY_TO_STRING(ColStringArray, ',')) STORED
+)PRIMARY KEY (`ColInt64`)
+CREATE TABLE `Venues` (
+    `Code` STRING(10) NOT NULL,
+    `Name` STRING(100),
+    `Active` BOOL NOT NULL,
+    `Capacity` INT64,
+    `Ratings` ARRAY<FLOAT64>
+)PRIMARY KEY (`Code`)
+CREATE TABLE `Albums` (
+    `AlbumId` INT64 NOT NULL,
+    `Title` STRING(100) NOT NULL,
+    `ReleaseDate` DATE,
+    `SingerId` INT64 NOT NULL,
+    `MarketingBudget` INT64,
+ CONSTRAINT `FK_Albums_Singers` FOREIGN KEY (`SingerId`) REFERENCES `Singers` (`SingerId`),
+)PRIMARY KEY (`AlbumId`)
+CREATE TABLE `Concerts` (
+    `VenueCode` STRING(10) NOT NULL,
+    `StartTime` TIMESTAMP NOT NULL,
+    `SingerId` INT64 NOT NULL,
+    `Title` STRING(200),
+ CONSTRAINT `FK_Concerts_Singers` FOREIGN KEY (`SingerId`) REFERENCES `Singers` (`SingerId`),
+ CONSTRAINT `FK_Concerts_Venues` FOREIGN KEY (`VenueCode`) REFERENCES `Venues` (`Code`),
+)PRIMARY KEY (`VenueCode`, `StartTime`, `SingerId`)
+CREATE TABLE `Tracks` (
+    `AlbumId` INT64 NOT NULL,
+    `TrackId` INT64 NOT NULL,
+    `Title` STRING(200) NOT NULL,
+    `Duration` NUMERIC,
+    `LyricsLanguages` ARRAY<STRING(2)>,
+    `Lyrics` ARRAY<STRING(MAX)>,
+CONSTRAINT `Chk_Languages_Lyrics_Length_Equal` CHECK (ARRAY_LENGTH(LyricsLanguages) = ARRAY_LENGTH(Lyrics)),
+)PRIMARY KEY (`AlbumId`, `TrackId`),
+ INTERLEAVE IN PARENT `Albums` ON DELETE NO ACTION 
 
-CREATE TABLE Performances (
-    VenueCode STRING(10) NOT NULL,
-    SingerId INT64 NOT NULL,
-    StartTime TIMESTAMP NOT NULL,
-    ConcertStartTime TIMESTAMP NOT NULL,
-    AlbumId INT64 NOT NULL,
-    TrackId INT64 NOT NULL,
-    Rating FLOAT64,
- CONSTRAINT FK_Performances_Singers FOREIGN KEY (SingerId) REFERENCES Singers (SingerId),
- CONSTRAINT FK_Performances_Tracks FOREIGN KEY (AlbumId, TrackId) REFERENCES Tracks (AlbumId, TrackId),
- CONSTRAINT FK_Performances_Concerts FOREIGN KEY (VenueCode, ConcertStartTime, SingerId) REFERENCES Concerts (VenueCode, StartTime, SingerId),
-)PRIMARY KEY (VenueCode, SingerId, StartTime)
-CREATE INDEX AlbumsByAlbumTitle2 ON Albums (Title) STORING (MarketingBudget, ReleaseDate)
-CREATE INDEX Idx_Singers_FullName ON Singers (FullName)
-CREATE NULL_FILTERED INDEX IDX_TableWithAllColumnTypes_ColDate_ColCommitTS ON TableWithAllColumnTypes (ColDate, ColCommitTS)
-CREATE UNIQUE INDEX Idx_Tracks_AlbumId_Title ON Tracks (TrackId, Title)
+CREATE TABLE `Performances` (
+    `VenueCode` STRING(10) NOT NULL,
+    `SingerId` INT64 NOT NULL,
+    `StartTime` TIMESTAMP NOT NULL,
+    `ConcertStartTime` TIMESTAMP NOT NULL,
+    `AlbumId` INT64 NOT NULL,
+    `TrackId` INT64 NOT NULL,
+    `Rating` FLOAT64,
+ CONSTRAINT `FK_Performances_Singers` FOREIGN KEY (`SingerId`) REFERENCES `Singers` (`SingerId`),
+ CONSTRAINT `FK_Performances_Tracks` FOREIGN KEY (`AlbumId`, `TrackId`) REFERENCES `Tracks` (`AlbumId`, `TrackId`),
+ CONSTRAINT `FK_Performances_Concerts` FOREIGN KEY (`VenueCode`, `ConcertStartTime`, `SingerId`) REFERENCES `Concerts` (`VenueCode`, `StartTime`, `SingerId`),
+)PRIMARY KEY (`VenueCode`, `SingerId`, `StartTime`)
+CREATE INDEX `AlbumsByAlbumTitle2` ON `Albums` (`Title`) STORING (`MarketingBudget`, `ReleaseDate`)
+CREATE INDEX `Idx_Singers_FullName` ON `Singers` (`FullName`)
+CREATE NULL_FILTERED INDEX `IDX_TableWithAllColumnTypes_ColDate_ColCommitTS` ON `TableWithAllColumnTypes` (`ColDate`, `ColCommitTS`)
+CREATE UNIQUE INDEX `Idx_Tracks_AlbumId_Title` ON `Tracks` (`TrackId`, `Title`)

--- a/Google.Cloud.EntityFrameworkCore.Spanner.Tests/Migrations/SpannerHistoryRepositoryTest.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.Tests/Migrations/SpannerHistoryRepositoryTest.cs
@@ -34,13 +34,13 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests.Migrations
             var sql = CreateHistoryRepository().GetCreateScript();
 
             Assert.Equal(
-                "CREATE TABLE EFMigrationsHistory ("
+                "CREATE TABLE `EFMigrationsHistory` ("
                 + EOL
-                + "    MigrationId STRING(150) NOT NULL,"
+                + "    `MigrationId` STRING(150) NOT NULL,"
                 + EOL
-                + "    ProductVersion STRING(32) NOT NULL"
+                + "    `ProductVersion` STRING(32) NOT NULL"
                 + EOL
-                + ")PRIMARY KEY (MigrationId)",
+                + ")PRIMARY KEY (`MigrationId`)",
                 sql);
         }
 

--- a/Google.Cloud.EntityFrameworkCore.Spanner.Tests/Migrations/SpannerMigrationSqlGeneratorTest.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.Tests/Migrations/SpannerMigrationSqlGeneratorTest.cs
@@ -499,35 +499,35 @@ WHERE `SingerId` = 4;
         public override void AlterColumnOperation()
         {
             base.AlterColumnOperation();
-            AssertSql(@"ALTER TABLE Singers ALTER COLUMN CharColumn STRING(MAX)");
+            AssertSql(@"ALTER TABLE `Singers` ALTER COLUMN `CharColumn` STRING(MAX)");
         }
 
         [Fact]
         public override void AlterColumnOperation_Add_Commit_Timestamp()
         {
             base.AlterColumnOperation_Add_Commit_Timestamp();
-            AssertSql(@"ALTER TABLE Singers ALTER COLUMN ColCommitTimestamp SET OPTIONS (allow_commit_timestamp=true) ");
+            AssertSql(@"ALTER TABLE `Singers` ALTER COLUMN `ColCommitTimestamp` SET OPTIONS (allow_commit_timestamp=true) ");
         }
 
         [Fact]
         public override void AlterColumnOperation_Remove_Commit_Timestamp()
         {
             base.AlterColumnOperation_Remove_Commit_Timestamp();
-            AssertSql(@"ALTER TABLE Singers ALTER COLUMN ColCommitTimestamp SET OPTIONS (allow_commit_timestamp=null) ");
+            AssertSql(@"ALTER TABLE `Singers` ALTER COLUMN `ColCommitTimestamp` SET OPTIONS (allow_commit_timestamp=null) ");
         }
 
         [Fact]
         public override void AlterColumnOperation_Make_type_not_null()
         {
             base.AlterColumnOperation_Make_type_not_null();
-            AssertSql(@"ALTER TABLE Singers ALTER COLUMN ColLong INT64 NOT NULL");
+            AssertSql(@"ALTER TABLE `Singers` ALTER COLUMN `ColLong` INT64 NOT NULL");
         }
 
         [Fact]
         public override void AlterColumnOperation_Make_type_nullable()
         {
             base.AlterColumnOperation_Make_type_nullable();
-            AssertSql(@"ALTER TABLE Singers ALTER COLUMN ColLong INT64");
+            AssertSql(@"ALTER TABLE `Singers` ALTER COLUMN `ColLong` INT64");
         }
 
         [Fact]

--- a/Google.Cloud.EntityFrameworkCore.Spanner.Tests/Migrations/SpannerMigrationSqlGeneratorTest.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.Tests/Migrations/SpannerMigrationSqlGeneratorTest.cs
@@ -26,14 +26,14 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests.Migrations
         {
             base.CreateTableOperation();
             AssertSql(
-                @"CREATE TABLE Albums (
-    AlbumId INT64 NOT NULL,
-    Title STRING(MAX) NOT NULL,
-    ReleaseDate DATE,
-    SingerId INT64 NOT NULL,
- CONSTRAINT FK_Albums_Singers FOREIGN KEY (SingerId) REFERENCES Singers (SingerId),
-CONSTRAINT Chk_Title_Length_Equal CHECK (CHARACTER_LENGTH(Title) > 0),
-)PRIMARY KEY (AlbumId)");
+                @"CREATE TABLE `Albums` (
+    `AlbumId` INT64 NOT NULL,
+    `Title` STRING(MAX) NOT NULL,
+    `ReleaseDate` DATE,
+    `SingerId` INT64 NOT NULL,
+ CONSTRAINT `FK_Albums_Singers` FOREIGN KEY (`SingerId`) REFERENCES `Singers` (`SingerId`),
+CONSTRAINT `Chk_Title_Length_Equal` CHECK (CHARACTER_LENGTH(Title) > 0),
+)PRIMARY KEY (`AlbumId`)");
         }
 
         [Fact]
@@ -41,42 +41,42 @@ CONSTRAINT Chk_Title_Length_Equal CHECK (CHARACTER_LENGTH(Title) > 0),
         {
             base.CreateTableWithAllColTypes();
             AssertSql(
-                @"CREATE TABLE AllColTypes (
-    Id INT64 NOT NULL,
-    ColShort INT64,
-    ColLong INT64,
-    ColByte INT64,
-    ColSbyte INT64,
-    ColULong INT64,
-    ColUShort INT64,
-    ColDecimal NUMERIC,
-    ColUint INT64,
-    ColBool BOOL,
-    ColDate DATE,
-    ColTimestamp TIMESTAMP,
-    ColCommitTimestamp TIMESTAMP OPTIONS (allow_commit_timestamp=true) ,
-    ColFloat FLOAT64,
-    ColDouble FLOAT64,
-    ColString STRING(MAX),
-    ColGuid STRING(36),
-    ColBytes BYTES(MAX),
-    ColDecimalArray ARRAY<NUMERIC>,
-    ColDecimalList ARRAY<NUMERIC>,
-    ColStringArray ARRAY<STRING(MAX)>,
-    ColStringList ARRAY<STRING(MAX)>,
-    ColBoolArray ARRAY<BOOL>,
-    ColBoolList ARRAY<BOOL>,
-    ColDoubleArray ARRAY<FLOAT64>,
-    ColDoubleList ARRAY<FLOAT64>,
-    ColLongArray ARRAY<INT64>,
-    ColLongList ARRAY<INT64>,
-    ColDateArray ARRAY<DATE>,
-    ColDateList ARRAY<DATE>,
-    ColTimestampArray ARRAY<TIMESTAMP>,
-    ColTimestampList ARRAY<TIMESTAMP>,
-    ColBytesArray ARRAY<BYTES(MAX)>,
-    ColBytesList ARRAY<BYTES(MAX)>
-)PRIMARY KEY (AlbumId)");
+                @"CREATE TABLE `AllColTypes` (
+    `Id` INT64 NOT NULL,
+    `ColShort` INT64,
+    `ColLong` INT64,
+    `ColByte` INT64,
+    `ColSbyte` INT64,
+    `ColULong` INT64,
+    `ColUShort` INT64,
+    `ColDecimal` NUMERIC,
+    `ColUint` INT64,
+    `ColBool` BOOL,
+    `ColDate` DATE,
+    `ColTimestamp` TIMESTAMP,
+    `ColCommitTimestamp` TIMESTAMP OPTIONS (allow_commit_timestamp=true) ,
+    `ColFloat` FLOAT64,
+    `ColDouble` FLOAT64,
+    `ColString` STRING(MAX),
+    `ColGuid` STRING(36),
+    `ColBytes` BYTES(MAX),
+    `ColDecimalArray` ARRAY<NUMERIC>,
+    `ColDecimalList` ARRAY<NUMERIC>,
+    `ColStringArray` ARRAY<STRING(MAX)>,
+    `ColStringList` ARRAY<STRING(MAX)>,
+    `ColBoolArray` ARRAY<BOOL>,
+    `ColBoolList` ARRAY<BOOL>,
+    `ColDoubleArray` ARRAY<FLOAT64>,
+    `ColDoubleList` ARRAY<FLOAT64>,
+    `ColLongArray` ARRAY<INT64>,
+    `ColLongList` ARRAY<INT64>,
+    `ColDateArray` ARRAY<DATE>,
+    `ColDateList` ARRAY<DATE>,
+    `ColTimestampArray` ARRAY<TIMESTAMP>,
+    `ColTimestampList` ARRAY<TIMESTAMP>,
+    `ColBytesArray` ARRAY<BYTES(MAX)>,
+    `ColBytesList` ARRAY<BYTES(MAX)>
+)PRIMARY KEY (`AlbumId`)");
         }
 
         [Fact]
@@ -84,8 +84,8 @@ CONSTRAINT Chk_Title_Length_Equal CHECK (CHARACTER_LENGTH(Title) > 0),
         {
             base.CreateTableOperation_no_key();
             AssertSql(
-                @"CREATE TABLE Anonymous (
-    Value INT64 NOT NULL
+                @"CREATE TABLE `Anonymous` (
+    `Value` INT64 NOT NULL
 )");
         }
 
@@ -93,42 +93,42 @@ CONSTRAINT Chk_Title_Length_Equal CHECK (CHARACTER_LENGTH(Title) > 0),
         public override void CreateIndexOperation()
         {
             base.CreateIndexOperation();
-            AssertSql(@"CREATE INDEX IX_Singer_FullName ON Singer (FullName)");
+            AssertSql(@"CREATE INDEX `IX_Singer_FullName` ON `Singer` (`FullName`)");
         }
 
         [Fact]
         public override void CreateIndexOperation_is_null_filtered()
         {
             base.CreateIndexOperation_is_null_filtered();
-            AssertSql(@"CREATE NULL_FILTERED INDEX IX_Singer_FullName ON Singer (FullName)");
+            AssertSql(@"CREATE NULL_FILTERED INDEX `IX_Singer_FullName` ON `Singer` (`FullName`)");
         }
 
         [Fact]
         public override void CreateIndexOperation_is_unique()
         {
             base.CreateIndexOperation_is_unique();
-            AssertSql(@"CREATE UNIQUE INDEX IX_Singer_FullName ON Singer (FullName)");
+            AssertSql(@"CREATE UNIQUE INDEX `IX_Singer_FullName` ON `Singer` (`FullName`)");
         }
 
         [Fact]
         public override void CreateIndexOperation_storing()
         {
             base.CreateIndexOperation_storing();
-            AssertSql(@"CREATE INDEX AlbumsByAlbumTitle2 ON Albums (AlbumTitle) STORING (MarketingBudget)");
+            AssertSql(@"CREATE INDEX `AlbumsByAlbumTitle2` ON `Albums` (`AlbumTitle`) STORING (`MarketingBudget`)");
         }
 
         [Fact]
         public override void CreateIndexOperation_storing_with_multiple_columns()
         {
             base.CreateIndexOperation_storing_with_multiple_columns();
-            AssertSql(@"CREATE INDEX AlbumsByAlbumTitle2 ON Albums (AlbumTitle) STORING (MarketingBudget, ReleaseDate)");
+            AssertSql(@"CREATE INDEX `AlbumsByAlbumTitle2` ON `Albums` (`AlbumTitle`) STORING (`MarketingBudget`, `ReleaseDate`)");
         }
 
         [Fact]
         public override void AddColumOperation()
         {
             base.AddColumOperation();
-            AssertSql(@"ALTER TABLE Singer ADD Name STRING(30) NOT NULL
+            AssertSql(@"ALTER TABLE `Singer` ADD `Name` STRING(30) NOT NULL
 ");
         }
 
@@ -136,7 +136,7 @@ CONSTRAINT Chk_Title_Length_Equal CHECK (CHARACTER_LENGTH(Title) > 0),
         public override void AddColumnOperation_with_computedSql()
         {
             base.AddColumnOperation_with_computedSql();
-            AssertSql(@"ALTER TABLE Singer ADD FullName STRING(MAX) NOT NULL AS (COALESCE(FirstName || ' ', '') || LastName) STORED
+            AssertSql(@"ALTER TABLE `Singer` ADD `FullName` STRING(MAX) NOT NULL AS (COALESCE(FirstName || ' ', '') || LastName) STORED
 ");
         }
 
@@ -144,7 +144,7 @@ CONSTRAINT Chk_Title_Length_Equal CHECK (CHARACTER_LENGTH(Title) > 0),
         public override void AddColumnOperation_with_update_commit_timestamp()
         {
             base.AddColumnOperation_with_update_commit_timestamp();
-            AssertSql(@"ALTER TABLE Album ADD CreatedDate TIMESTAMP NOT NULL OPTIONS (allow_commit_timestamp=true) 
+            AssertSql(@"ALTER TABLE `Album` ADD `CreatedDate` TIMESTAMP NOT NULL OPTIONS (allow_commit_timestamp=true) 
 ");
         }
 
@@ -152,7 +152,7 @@ CONSTRAINT Chk_Title_Length_Equal CHECK (CHARACTER_LENGTH(Title) > 0),
         public override void AddColumnOperation_without_column_type()
         {
             base.AddColumnOperation_without_column_type();
-            AssertSql(@"ALTER TABLE Singer ADD FullName STRING(MAX) NOT NULL
+            AssertSql(@"ALTER TABLE `Singer` ADD `FullName` STRING(MAX) NOT NULL
 ");
         }
 
@@ -160,7 +160,7 @@ CONSTRAINT Chk_Title_Length_Equal CHECK (CHARACTER_LENGTH(Title) > 0),
         public override void AddColumnOperation_with_column_type()
         {
             base.AddColumnOperation_with_column_type();
-            AssertSql(@"ALTER TABLE Singer ADD FullName ARRAY<STRING(200)> NOT NULL
+            AssertSql(@"ALTER TABLE `Singer` ADD `FullName` ARRAY<STRING(200)> NOT NULL
 ");
         }
 
@@ -168,7 +168,7 @@ CONSTRAINT Chk_Title_Length_Equal CHECK (CHARACTER_LENGTH(Title) > 0),
         public override void AddColumnOperation_with_maxLength()
         {
             base.AddColumnOperation_with_maxLength();
-            AssertSql(@"ALTER TABLE Singer ADD FullName STRING(30)
+            AssertSql(@"ALTER TABLE `Singer` ADD `FullName` STRING(30)
 ");
         }
 
@@ -176,7 +176,7 @@ CONSTRAINT Chk_Title_Length_Equal CHECK (CHARACTER_LENGTH(Title) > 0),
         public override void AddColumnOperation_with_maxLength_no_model()
         {
             base.AddColumnOperation_with_maxLength_no_model();
-            AssertSql(@"ALTER TABLE Singer ADD FullName STRING(30)
+            AssertSql(@"ALTER TABLE `Singer` ADD `FullName` STRING(30)
 ");
         }
 
@@ -184,7 +184,7 @@ CONSTRAINT Chk_Title_Length_Equal CHECK (CHARACTER_LENGTH(Title) > 0),
         public override void AddColumnOperation_with_maxLength_overridden()
         {
             base.AddColumnOperation_with_maxLength_overridden();
-            AssertSql(@"ALTER TABLE Singer ADD FullName STRING(32)
+            AssertSql(@"ALTER TABLE `Singer` ADD `FullName` STRING(32)
 ");
         }
 
@@ -192,7 +192,7 @@ CONSTRAINT Chk_Title_Length_Equal CHECK (CHARACTER_LENGTH(Title) > 0),
         public override void AddColumnOperation_with_maxLength_on_derived()
         {
             base.AddColumnOperation_with_maxLength_on_derived();
-            AssertSql(@"ALTER TABLE Singer ADD Name STRING(30)
+            AssertSql(@"ALTER TABLE `Singer` ADD `Name` STRING(30)
 ");
         }
 
@@ -200,7 +200,7 @@ CONSTRAINT Chk_Title_Length_Equal CHECK (CHARACTER_LENGTH(Title) > 0),
         public override void AddColumnOperation_with_shared_column()
         {
             base.AddColumnOperation_with_shared_column();
-            AssertSql(@"ALTER TABLE VersionedEntity ADD Version INT64
+            AssertSql(@"ALTER TABLE `VersionedEntity` ADD `Version` INT64
 ");
         }
 
@@ -223,7 +223,7 @@ CONSTRAINT Chk_Title_Length_Equal CHECK (CHARACTER_LENGTH(Title) > 0),
         public override void AddForeignKeyOperation_with_name()
         {
             base.AddForeignKeyOperation_with_name();
-            AssertSql(@"ALTER TABLE Album ADD  CONSTRAINT FK_Album_Singer FOREIGN KEY (SingerId) REFERENCES Singer (SingerId)
+            AssertSql(@"ALTER TABLE `Album` ADD  CONSTRAINT `FK_Album_Singer` FOREIGN KEY (`SingerId`) REFERENCES `Singer` (`SingerId`)
 ");
         }
 
@@ -231,7 +231,7 @@ CONSTRAINT Chk_Title_Length_Equal CHECK (CHARACTER_LENGTH(Title) > 0),
         public override void AddForeignKeyOperation_with_multiple_column()
         {
             base.AddForeignKeyOperation_with_multiple_column();
-            AssertSql(@"ALTER TABLE Performances ADD  CONSTRAINT FK_Performances_Concerts FOREIGN KEY (VenueCode, ConcertStartTime, SingerId) REFERENCES Concerts (VenueCode, StartTime, SingerId)
+            AssertSql(@"ALTER TABLE `Performances` ADD  CONSTRAINT `FK_Performances_Concerts` FOREIGN KEY (`VenueCode`, `ConcertStartTime`, `SingerId`) REFERENCES `Concerts` (`VenueCode`, `StartTime`, `SingerId`)
 ");
         }
 
@@ -253,7 +253,7 @@ CONSTRAINT Chk_Title_Length_Equal CHECK (CHARACTER_LENGTH(Title) > 0),
         public void CreateDatabaseOperation()
         {
             Generate(new SpannerCreateDatabaseOperation { Name = "Northwind" });
-            AssertSql(@"CREATE DATABASE Northwind");
+            AssertSql(@"CREATE DATABASE `Northwind`");
         }
 
         [Fact]
@@ -274,7 +274,7 @@ CONSTRAINT Chk_Title_Length_Equal CHECK (CHARACTER_LENGTH(Title) > 0),
         public override void CreateCheckConstraintOperation_with_name()
         {
             base.CreateCheckConstraintOperation_with_name();
-            AssertSql(@"ALTER TABLE Singers ADD CONSTRAINT Chk_Title_Length_Equal CHECK (CHARACTER_LENGTH(Title) > 0)
+            AssertSql(@"ALTER TABLE `Singers` ADD CONSTRAINT `Chk_Title_Length_Equal` CHECK (CHARACTER_LENGTH(Title) > 0)
 ");
         }
 
@@ -282,7 +282,7 @@ CONSTRAINT Chk_Title_Length_Equal CHECK (CHARACTER_LENGTH(Title) > 0),
         public override void DropColumnOperation()
         {
             base.DropColumnOperation();
-            AssertSql(@"ALTER TABLE Singer DROP COLUMN FullName
+            AssertSql(@"ALTER TABLE `Singer` DROP COLUMN `FullName`
 ");
         }
 
@@ -290,7 +290,7 @@ CONSTRAINT Chk_Title_Length_Equal CHECK (CHARACTER_LENGTH(Title) > 0),
         public override void DropForeignKeyOperation()
         {
             base.DropForeignKeyOperation();
-            AssertSql(@"ALTER TABLE Album DROP CONSTRAINT FK_Album_Singers
+            AssertSql(@"ALTER TABLE `Album` DROP CONSTRAINT `FK_Album_Singers`
 ");
         }
 
@@ -298,14 +298,14 @@ CONSTRAINT Chk_Title_Length_Equal CHECK (CHARACTER_LENGTH(Title) > 0),
         public override void DropIndexOperation()
         {
             base.DropIndexOperation();
-            AssertSql(@" DROP INDEX IX_Singer_FullName");
+            AssertSql(@" DROP INDEX `IX_Singer_FullName`");
         }
 
         [Fact]
         public override void DropTableOperation()
         {
             base.DropTableOperation();
-            AssertSql(@"DROP TABLE Singer
+            AssertSql(@"DROP TABLE `Singer`
 ");
         }
 
@@ -313,7 +313,7 @@ CONSTRAINT Chk_Title_Length_Equal CHECK (CHARACTER_LENGTH(Title) > 0),
         public override void DropCheckConstraintOperation()
         {
             base.DropCheckConstraintOperation();
-            AssertSql(@"ALTER TABLE Singer DROP CONSTRAINT CK_Singer_FullName
+            AssertSql(@"ALTER TABLE `Singer` DROP CONSTRAINT `CK_Singer_FullName`
 ");
         }
 
@@ -321,7 +321,7 @@ CONSTRAINT Chk_Title_Length_Equal CHECK (CHARACTER_LENGTH(Title) > 0),
         public void DropDatabaseOperation()
         {
             Generate(new SpannerDropDatabaseOperation { Name = "Northwind" });
-            AssertSql(@"DROP DATABASE Northwind");
+            AssertSql(@"DROP DATABASE `Northwind`");
         }
 
         [Fact]
@@ -399,7 +399,7 @@ CONSTRAINT Chk_Title_Length_Equal CHECK (CHARACTER_LENGTH(Title) > 0),
         public override void AddUniqueConstraintOperation()
         {
             base.AddUniqueConstraintOperation();
-            AssertSql(@"ALTER TABLE Singer ADD CONSTRAINT Unique_Name UNIQUE (FirstName, LastName)
+            AssertSql(@"ALTER TABLE `Singer` ADD CONSTRAINT `Unique_Name` UNIQUE (`FirstName`, `LastName`)
 ");
         }
 
@@ -407,7 +407,7 @@ CONSTRAINT Chk_Title_Length_Equal CHECK (CHARACTER_LENGTH(Title) > 0),
         public override void DropUniqueConstraintOperation()
         {
             base.DropUniqueConstraintOperation();
-            AssertSql(@"ALTER TABLE Singer DROP CONSTRAINT Unique_Name
+            AssertSql(@"ALTER TABLE `Singer` DROP CONSTRAINT `Unique_Name`
 ");
         }
 
@@ -432,7 +432,7 @@ CONSTRAINT Chk_Title_Length_Equal CHECK (CHARACTER_LENGTH(Title) > 0),
         public override void InsertDataOperation()
         {
             base.InsertDataOperation();
-            AssertSql(@"INSERT INTO Singer (SingerId, FirstName, LastName)
+            AssertSql(@"INSERT INTO `Singer` (`SingerId`, `FirstName`, `LastName`)
 VALUES (1, 'Marc', 'Richards'),
 (2, 'Catalina', 'Smith'),
 (3, 'Alice', 'Trentor'),
@@ -444,10 +444,10 @@ VALUES (1, 'Marc', 'Richards'),
         public override void DeleteDataOperation_simple_key()
         {
             base.DeleteDataOperation_simple_key();
-            AssertSql(@"DELETE FROM Singer
-WHERE SingerId = 1;
-DELETE FROM Singer
-WHERE SingerId = 3;
+            AssertSql(@"DELETE FROM `Singer`
+WHERE `SingerId` = 1;
+DELETE FROM `Singer`
+WHERE `SingerId` = 3;
 ");
         }
 
@@ -455,10 +455,10 @@ WHERE SingerId = 3;
         public override void DeleteDataOperation_composite_key()
         {
             base.DeleteDataOperation_composite_key();
-            AssertSql(@"DELETE FROM Singer
-WHERE FirstName = 'Dorothy' AND LastName IS NULL;
-DELETE FROM Singer
-WHERE FirstName = 'Curt' AND LastName = 'Lee';
+            AssertSql(@"DELETE FROM `Singer`
+WHERE `FirstName` = 'Dorothy' AND `LastName` IS NULL;
+DELETE FROM `Singer`
+WHERE `FirstName` = 'Curt' AND `LastName` = 'Lee';
 ");
         }
 
@@ -466,10 +466,10 @@ WHERE FirstName = 'Curt' AND LastName = 'Lee';
         public override void UpdateDataOperation_simple_key()
         {
             base.UpdateDataOperation_simple_key();
-            AssertSql(@"UPDATE Singer SET FirstName = 'Christopher'
-WHERE SingerId = 1;
-UPDATE Singer SET FirstName = 'Lisa'
-WHERE SingerId = 4;
+            AssertSql(@"UPDATE `Singer` SET `FirstName` = 'Christopher'
+WHERE `SingerId` = 1;
+UPDATE `Singer` SET `FirstName` = 'Lisa'
+WHERE `SingerId` = 4;
 ");
         }
 
@@ -477,10 +477,10 @@ WHERE SingerId = 4;
         public override void UpdateDataOperation_composite_key()
         {
             base.UpdateDataOperation_composite_key();
-            AssertSql(@"UPDATE Album SET Title = 'Total Junk'
-WHERE SingerId = 1 AND AlbumId = 1;
-UPDATE Album SET Title = 'Terrified'
-WHERE SingerId = 1 AND AlbumId = 2;
+            AssertSql(@"UPDATE `Album` SET `Title` = 'Total Junk'
+WHERE `SingerId` = 1 AND `AlbumId` = 1;
+UPDATE `Album` SET `Title` = 'Terrified'
+WHERE `SingerId` = 1 AND `AlbumId` = 2;
 ");
         }
 
@@ -488,10 +488,10 @@ WHERE SingerId = 1 AND AlbumId = 2;
         public override void UpdateDataOperation_multiple_columns()
         {
             base.UpdateDataOperation_multiple_columns();
-            AssertSql(@"UPDATE Singer SET FirstName = 'Gregory', LastName = 'Davis'
-WHERE SingerId = 1;
-UPDATE Singer SET FirstName = 'Katherine', LastName = 'Palmer'
-WHERE SingerId = 4;
+            AssertSql(@"UPDATE `Singer` SET `FirstName` = 'Gregory', `LastName` = 'Davis'
+WHERE `SingerId` = 1;
+UPDATE `Singer` SET `FirstName` = 'Katherine', `LastName` = 'Palmer'
+WHERE `SingerId` = 4;
 ");
         }
 

--- a/Google.Cloud.EntityFrameworkCore.Spanner.Tests/TypeConversionTests.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.Tests/TypeConversionTests.cs
@@ -72,7 +72,9 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
         [Fact]
         public async Task TestEntity_ConvertValuesWithoutPrecisionLossOrOverflow_Succeeds()
         {
-            var sql = $"SELECT t.Id, t.ByteCol, t.DecimalCol, t.FloatCol{Environment.NewLine}FROM TestEntities AS t{Environment.NewLine}WHERE t.Id = @__p_0{Environment.NewLine}LIMIT 1";
+            var sql = $"SELECT `t`.`Id`, `t`.`ByteCol`, `t`.`DecimalCol`, `t`.`FloatCol`" +
+                $"{Environment.NewLine}FROM `TestEntities` AS `t`{Environment.NewLine}" +
+                $"WHERE `t`.`Id` = @__p_0{Environment.NewLine}LIMIT 1";
             _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateResultSet(
                 new List<Tuple<V1.Type, string>>
                 {
@@ -98,7 +100,9 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
         [Fact]
         public async Task TestEntity_ConvertValuesWithByteOverflow_Fails()
         {
-            var sql = $"SELECT t.Id, t.ByteCol, t.DecimalCol, t.FloatCol{Environment.NewLine}FROM TestEntities AS t{Environment.NewLine}WHERE t.Id = @__p_0{Environment.NewLine}LIMIT 1";
+            var sql = $"SELECT `t`.`Id`, `t`.`ByteCol`, `t`.`DecimalCol`, `t`.`FloatCol`" +
+                $"{Environment.NewLine}FROM `TestEntities` AS `t`{Environment.NewLine}" +
+                $"WHERE `t`.`Id` = @__p_0{Environment.NewLine}LIMIT 1";
             _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateResultSet(
                 new List<Tuple<V1.Type, string>>
                 {
@@ -120,7 +124,9 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
         [Fact]
         public async Task TestEntity_ConvertValuesWithFloatOverflow_Succeeds()
         {
-            var sql = $"SELECT t.Id, t.ByteCol, t.DecimalCol, t.FloatCol{Environment.NewLine}FROM TestEntities AS t{Environment.NewLine}WHERE t.Id = @__p_0{Environment.NewLine}LIMIT 1";
+            var sql = $"SELECT `t`.`Id`, `t`.`ByteCol`, `t`.`DecimalCol`, `t`.`FloatCol`" +
+                $"{Environment.NewLine}FROM `TestEntities` AS `t`{Environment.NewLine}" +
+                $"WHERE `t`.`Id` = @__p_0{Environment.NewLine}LIMIT 1";
             _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateResultSet(
                 new List<Tuple<V1.Type, string>>
                 {
@@ -143,7 +149,9 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
         [Fact]
         public async Task TestEntity_ConvertValuesWithDecimalOverflow_Fails()
         {
-            var sql = $"SELECT t.Id, t.ByteCol, t.DecimalCol, t.FloatCol{Environment.NewLine}FROM TestEntities AS t{Environment.NewLine}WHERE t.Id = @__p_0{Environment.NewLine}LIMIT 1";
+            var sql = $"SELECT `t`.`Id`, `t`.`ByteCol`, `t`.`DecimalCol`, `t`.`FloatCol`" +
+                $"{Environment.NewLine}FROM `TestEntities` AS `t`{Environment.NewLine}" +
+                $"WHERE `t`.`Id` = @__p_0{Environment.NewLine}LIMIT 1";
             _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateResultSet(
                 new List<Tuple<V1.Type, string>>
                 {

--- a/Google.Cloud.EntityFrameworkCore.Spanner/Migrations/Internal/SpannerHistoryRepository.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner/Migrations/Internal/SpannerHistoryRepository.cs
@@ -54,7 +54,8 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Migrations.Internal
 
                 var builder = new StringBuilder();
                 builder.Append("SELECT EXISTS(SELECT 1 FROM information_schema.tables WHERE table_catalog = '' and table_schema = '' and table_name = ")
-                    .Append($"{stringTypeMapping.GenerateSqlLiteral(SqlGenerationHelper.DelimitIdentifier(TableName, TableSchema))})");
+                    .Append($"{stringTypeMapping.GenerateSqlLiteral(Dependencies.SqlGenerationHelper.DelimitIdentifier(TableName, TableSchema))})");
+                builder.Replace("`", "");
                 return builder.ToString();
             }
         }

--- a/Google.Cloud.EntityFrameworkCore.Spanner/Migrations/SpannerMigrationsSqlGenerator.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner/Migrations/SpannerMigrationsSqlGenerator.cs
@@ -61,13 +61,13 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 if ((SpannerUpdateCommitTimestamp)commitTimestampAnnotation.Value != SpannerUpdateCommitTimestamp.Never)
                 {
                     builder
-                        .Append(operation.Name)
+                        .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(operation.Name))
                         .Append(" SET OPTIONS (allow_commit_timestamp=true) ");
                 }
                 else
                 {
                     builder
-                        .Append(operation.Name)
+                        .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(operation.Name))
                         .Append(" SET OPTIONS (allow_commit_timestamp=null) ");
                 }
             }

--- a/Google.Cloud.EntityFrameworkCore.Spanner/Migrations/SpannerMigrationsSqlGenerator.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner/Migrations/SpannerMigrationsSqlGenerator.cs
@@ -126,7 +126,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             }
 
             builder.Append("INDEX ")
-                .Append(operation.Name)
+                .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(operation.Name))
                 .Append(" ON ")
                 .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(operation.Table, operation.Schema))
                 .Append(" (")
@@ -278,7 +278,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 var parentTableName = model.FindEntityType(parentEntity).GetTableName();
                 builder.AppendLine(",")
                     .Append(" INTERLEAVE IN PARENT ")
-                    .Append(parentTableName)
+                    .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(parentTableName))
                     .Append(" ON DELETE ");
                 var onDeleteAttribute = operation.FindAnnotation(SpannerAnnotationNames.InterleaveInParentOnDelete);
                 builder.AppendLine(onDeleteAttribute != null && (OnDelete)onDeleteAttribute.Value == OnDelete.Cascade ? "CASCADE " : "NO ACTION ");
@@ -308,11 +308,11 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             MigrationCommandListBuilder builder)
         {
             builder.Append(" CONSTRAINT ")
-                .Append(operation.Name)
+                .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(operation.Name))
                 .Append(" FOREIGN KEY (")
                 .Append(ColumnList(operation.Columns))
                 .Append(") REFERENCES ")
-                .Append(operation.PrincipalTable)
+                .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(operation.PrincipalTable, operation.PrincipalSchema))
                 .Append(" (")
                 .Append(ColumnList(operation.PrincipalColumns))
                 .Append(")");

--- a/Google.Cloud.EntityFrameworkCore.Spanner/Storage/Internal/SpannerSqlGenerationHelper.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner/Storage/Internal/SpannerSqlGenerationHelper.cs
@@ -50,6 +50,22 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Storage.Internal
             builder.Append(GenerateParameterName(name));
         }
 
+        /// <inheritdoc />
+        public override void EscapeIdentifier(StringBuilder builder, string identifier)
+        {
+            GaxPreconditions.CheckNotNullOrEmpty(identifier, nameof(identifier));
+            var initialLength = builder.Length;
+            builder.Append(identifier);
+            builder.Replace("`", "\\`", initialLength, identifier.Length);
+        }
+
+        /// <inheritdoc />
+        public override string EscapeIdentifier(string identifier)
+        {
+            GaxPreconditions.CheckNotNullOrEmpty(identifier, nameof(identifier));
+            return identifier.Replace("`", "\\`");
+        }
+
         // Note we remove the schema because spanner does not support schema based names.
         /// <inheritdoc />
         public override string DelimitIdentifier(string name, string schema)

--- a/Google.Cloud.EntityFrameworkCore.Spanner/Storage/Internal/SpannerSqlGenerationHelper.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner/Storage/Internal/SpannerSqlGenerationHelper.cs
@@ -61,13 +61,15 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Storage.Internal
 
         /// <inheritdoc />
         public override string DelimitIdentifier(string identifier)
-            => $"{EscapeIdentifier(GaxPreconditions.CheckNotNullOrEmpty(identifier, nameof(identifier)))}";
+            => $"`{EscapeIdentifier(GaxPreconditions.CheckNotNullOrEmpty(identifier, nameof(identifier)))}`";
 
         /// <inheritdoc />
         public override void DelimitIdentifier(StringBuilder builder, string identifier)
         {
             GaxPreconditions.CheckNotNullOrEmpty(identifier, nameof(identifier));
+            builder.Append('`');
             EscapeIdentifier(builder, identifier);
+            builder.Append('`');
         }
     }
 }


### PR DESCRIPTION
In the current implementation while using [spanner reserved keywords](https://cloud.google.com/spanner/docs/lexical#reserved_keywords) as column/table/constraint name it is breaking in migration as well as performing the query on same.

**Step to reproduce:**

Schema:
```C#
public partial class Singers
{
    public long SingerId { get; set; }
    public string ASC { get; set; }
}
```

Query:
```C#
var db = new MyDbContext();
db.Singers.Add(new Singer
{	
    SingerId = 1,
    ASC = "Test"
});
db.SaveChanges();
```
Propose implementation is to use **backticks ( ` )** in all the query.