### PR TITLE
fix: the emulator now supports computed columns

### DIFF
--- a/Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests/MigrationTests/MigrationTestFixture.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests/MigrationTests/MigrationTestFixture.cs
@@ -42,34 +42,6 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests
                     .UseSpanner($"Data Source={_databaseName};emulatordetection=EmulatorOrProduction");
             }
         }
-
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            base.OnModelCreating(modelBuilder);
-            // Override some settings if the tests are executed against the emulator, as the emulator does
-            // not support all features of Spanner.
-            if (SpannerFixtureBase.IsEmulator)
-            {
-                // Simulate a generated column when testing against the emulator.
-                modelBuilder.Entity<Author>(entity =>
-                {
-                    entity.Property(e => e.FullName)
-                        .HasValueGenerator<AuthorFullNameGenerator>()
-                        .ValueGeneratedNever();
-                });
-            }
-        }
-    }
-
-    internal class AuthorFullNameGenerator : ValueGenerator<string>
-    {
-        public override bool GeneratesTemporaryValues => false;
-
-        public override string Next(EntityEntry entry)
-        {
-            var author = entry.Entity as Author;
-            return (author.FirstName ?? "") + " " + (author.LastName ?? "");
-        }
     }
 
     public class MigrationTestFixture : SpannerFixtureBase

--- a/Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests/MigrationTests/Migrations/20210324085522_Initial.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests/MigrationTests/Migrations/20210324085522_Initial.cs
@@ -65,7 +65,7 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests.MigrationTes
                     AuthorId = table.Column<long>(nullable: false),
                     FirstName = table.Column<string>(nullable: true),
                     LastName = table.Column<string>(nullable: true),
-                    FullName = table.Column<string>(nullable: true, computedColumnSql: SpannerFixtureBase.IsEmulator ? null : "(ARRAY_TO_STRING([FirstName, LastName], ' ')) STORED")
+                    FullName = table.Column<string>(nullable: true, computedColumnSql: "(ARRAY_TO_STRING([FirstName, LastName], ' ')) STORED")
                 },
                 constraints: table =>
                 {

--- a/Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests/MigrationTests/SpannerMigrationTest.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests/MigrationTests/SpannerMigrationTest.cs
@@ -543,10 +543,9 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests
             Assert.Equal("Loren Ritchie", author.FullName);
         }
 
-        [SkippableFact]
+        [Fact]
         public async Task CanSeedData()
         {
-            Skip.If(SpannerFixtureBase.IsEmulator, "Emulator does not support Computed columns");
             using var context = new TestMigrationDbContext(_fixture.DatabaseName);
             var authors = await context.Authors.Where(c => c.AuthorId == 1 || c.AuthorId == 2).ToListAsync();
             if (_fixture.Database.Fresh)

--- a/Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests/xunit.runner.json
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests/xunit.runner.json
@@ -1,4 +1,5 @@
 {
     "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
-    "parallelizeTestCollections": true
+    "parallelizeTestCollections": true,
+    "maxParallelThreads":  16
 }


### PR DESCRIPTION
The emulator now supports computed columns, as long as the computed column is the last column in the table.

Fixes [this build error](https://github.com/cloudspannerecosystem/dotnet-spanner-entity-framework/pull/72/checks?check_run_id=2202481074).
