### PR TITLE
feat: validate entity model against database

### DIFF
--- a/Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests/ModelValidationTests/Model/Album.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests/ModelValidationTests/Model/Album.cs
@@ -12,15 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests.Model;
-
-namespace Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests.VersioningTests.Model
+namespace Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests.ModelValidationTests
 {
-    public partial class AlbumsWithVersion : VersionedEntity
+    public partial class Album
     {
-        public long AlbumId { get; set; }
         public long SingerId { get; set; }
+        public long AlbumId { get; set; }
         public string Title { get; set; }
-        public virtual SingersWithVersion Singer { get; set; }
+        public virtual Singer Singer { get; set; }
     }
 }

--- a/Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests/ModelValidationTests/Model/InvalidChildEntityDbContext.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests/ModelValidationTests/Model/InvalidChildEntityDbContext.cs
@@ -1,0 +1,47 @@
+﻿// Copyright 2021 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Cloud.Spanner.Common.V1;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+
+namespace Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests.ModelValidationTests
+{
+
+    /// <summary>
+    /// Context that uses a model where the key of a child entity (Album) does not correspond
+    /// with an existing primary key or unique index. This should trigger a validation error.
+    /// </summary>
+    public class InvalidChildEntityDbContext : ValidDbContext
+    {
+        public InvalidChildEntityDbContext(DatabaseName databaseName) : base(databaseName)
+        {
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Singer>(entity =>
+            {
+                entity.HasKey(e => e.SingerId);
+            });
+
+            modelBuilder.Entity<Album>(entity =>
+            {
+                entity
+                    .InterleaveInParent(typeof(Singer), OnDelete.Cascade)
+                    .HasKey(entity => new { entity.AlbumId }); // This should have included SingerId.
+            });
+        }
+    }
+}

--- a/Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests/ModelValidationTests/Model/InvalidEntityDbContext.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests/ModelValidationTests/Model/InvalidEntityDbContext.cs
@@ -1,0 +1,47 @@
+﻿// Copyright 2021 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Cloud.Spanner.Common.V1;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+
+namespace Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests.ModelValidationTests
+{
+
+    /// <summary>
+    /// Context that uses a model where the key of an entity (Singer) does not correspond
+    /// with an existing primary key or unique index. This should trigger a validation error.
+    /// </summary>
+    public class InvalidEntityDbContext : ValidDbContext
+    {
+        public InvalidEntityDbContext(DatabaseName databaseName) : base(databaseName)
+        {
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Singer>(entity =>
+            {
+                entity.HasKey(e => e.LastName); // This is not a primary key or unique index
+            });
+
+            modelBuilder.Entity<Album>(entity =>
+            {
+                entity
+                    .InterleaveInParent(typeof(Singer), OnDelete.Cascade)
+                    .HasKey(entity => new { entity.SingerId, entity.AlbumId });
+            });
+        }
+    }
+}

--- a/Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests/ModelValidationTests/Model/ModelValidationTestFixture.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests/ModelValidationTests/Model/ModelValidationTestFixture.cs
@@ -1,0 +1,69 @@
+﻿// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Api.Gax;
+
+namespace Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests.ModelValidationTests
+{
+    public class ModelValidationTestFixture : SpannerFixtureBase
+    {
+        public ModelValidationTestFixture()
+        {
+            if (Database.Fresh)
+            {
+                CreateTables();
+            }
+            else
+            {
+                ClearTables();
+            }
+        }
+
+        private void ClearTables()
+        {
+            using var con = GetConnection();
+            con.RunWithRetriableTransactionAsync((transaction) =>
+            {
+                var cmd = transaction.CreateBatchDmlCommand();
+                foreach (var table in new string[]
+                {
+                    "Singers",
+                })
+                {
+                    cmd.Add($"DELETE FROM {table} WHERE TRUE");
+                }
+                return cmd.ExecuteNonQueryAsync();
+            }).ResultWithUnwrappedExceptions();
+        }
+
+        private void CreateTables()
+        {
+            using var connection = GetConnection();
+            connection.CreateDdlCommand(
+                @"CREATE TABLE Singers (
+                    SingerId INT64,
+                    FirstName STRING(MAX),
+                    LastName STRING(MAX),
+                 ) PRIMARY KEY (SingerId)",
+                @"CREATE TABLE Albums (
+                    SingerId INT64,
+                    AlbumId INT64,
+                    Title STRING(MAX),
+                 ) PRIMARY KEY (SingerId, AlbumId),
+                 INTERLEAVE IN PARENT Singers ON DELETE CASCADE",
+                @"CREATE UNIQUE INDEX Idx_Albums_SingerTitle ON Albums (SingerId, Title)"
+            ).ExecuteNonQuery();
+        }
+    }
+}

--- a/Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests/ModelValidationTests/Model/ModelWithUniqueIndexAsKeyDbContext.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests/ModelValidationTests/Model/ModelWithUniqueIndexAsKeyDbContext.cs
@@ -1,0 +1,50 @@
+﻿// Copyright 2021 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Cloud.Spanner.Common.V1;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+
+namespace Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests.ModelValidationTests
+{
+
+    /// <summary>
+    /// Context that uses a model where the key of an entity (Album) does not correspond
+    /// with the primary key of the table, but it does correspond with a unique index that
+    /// is not null-filtered. This should NOT trigger a validation error.
+    /// </summary>
+    public class ModelWithUniqueIndexAsKeyDbContext : ValidDbContext
+    {
+        public ModelWithUniqueIndexAsKeyDbContext(DatabaseName databaseName) : base(databaseName)
+        {
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Singer>(entity =>
+            {
+                entity.HasKey(e => e.SingerId);
+            });
+
+            modelBuilder.Entity<Album>(entity =>
+            {
+                entity
+                    .InterleaveInParent(typeof(Singer), OnDelete.Cascade)
+                    // This is not the primary key, but there is a unique index
+                    // on (SingerId, Title). This is therefore allowed as a key.
+                    .HasKey(entity => new { entity.SingerId, entity.Title });
+            });
+        }
+    }
+}

--- a/Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests/ModelValidationTests/Model/Singer.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests/ModelValidationTests/Model/Singer.cs
@@ -12,15 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests.Model;
-
-namespace Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests.VersioningTests.Model
+namespace Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests.ModelValidationTests
 {
-    public partial class AlbumsWithVersion : VersionedEntity
+    public partial class Singer
     {
-        public long AlbumId { get; set; }
         public long SingerId { get; set; }
-        public string Title { get; set; }
-        public virtual SingersWithVersion Singer { get; set; }
+        public string FirstName { get; set; }
+        public string LastName { get; set; }
     }
 }

--- a/Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests/ModelValidationTests/Model/ValidDbContext.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests/ModelValidationTests/Model/ValidDbContext.cs
@@ -1,0 +1,55 @@
+﻿// Copyright 2021 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Cloud.Spanner.Common.V1;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+
+namespace Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests.ModelValidationTests
+{
+    public class ValidDbContext : DbContext
+    {
+        private readonly DatabaseName _databaseName;
+
+        public ValidDbContext(DatabaseName databaseName) => _databaseName = databaseName;
+
+        public virtual DbSet<Singer> Singers { get; set; }
+        public virtual DbSet<Album> Albums { get; set; }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Singer>(entity =>
+            {
+                entity.HasKey(e => e.SingerId);
+            });
+
+            modelBuilder.Entity<Album>(entity =>
+            {
+                entity
+                    .InterleaveInParent(typeof(Singer), OnDelete.Cascade)
+                    .HasKey(entity => new { entity.SingerId, entity.AlbumId });
+            });
+        }
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        {
+            if (!optionsBuilder.IsConfigured)
+            {
+                optionsBuilder
+                    .UseLazyLoadingProxies()
+                    .UseSpanner($"Data Source={_databaseName};emulatordetection=EmulatorOrProduction");
+            }
+        }
+    }
+}

--- a/Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests/ModelValidationTests/ModelValidationTests.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests/ModelValidationTests/ModelValidationTests.cs
@@ -34,8 +34,8 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests.ModelValidat
         {
             // Reset the connection string provider for model validation. This ensures that the validation
             // is executed regardless whether these tests execute before or after the other integration tests.
-            ModelValidationConnectionStringProvider.Reset();
-            ModelValidationConnectionStringProvider.EnableDatabaseModelValidation(true);
+            SpannerModelValidationConnectionProvider.Instance.Reset();
+            SpannerModelValidationConnectionProvider.Instance.EnableDatabaseModelValidation(true);
             _fixture = fixture;
         }
 

--- a/Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests/ModelValidationTests/ModelValidationTests.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests/ModelValidationTests/ModelValidationTests.cs
@@ -1,0 +1,105 @@
+﻿// Copyright 2021, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Cloud.EntityFrameworkCore.Spanner.Extensions;
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests.ModelValidationTests
+{
+    /// <summary>
+    /// Integration tests for model validation against an actual database. These tests cannot execute
+    /// in parallel with the other integration tests, as model validation against a database is only
+    /// supported as long as the provider is only being used for one database. As each test uses its
+    /// own database, this is not the case for integration tests.
+    /// </summary>
+    [Collection(nameof(NonParallelTestCollection))]
+    public class ModelValidationTests : IClassFixture<ModelValidationTestFixture>
+    {
+        private readonly ModelValidationTestFixture _fixture;
+
+        public ModelValidationTests(ModelValidationTestFixture fixture)
+        {
+            // Reset the connection string provider for model validation. This ensures that the validation
+            // is executed regardless whether these tests execute before or after the other integration tests.
+            ModelValidationConnectionStringProvider.Reset();
+            ModelValidationConnectionStringProvider.EnableDatabaseModelValidation(true);
+            _fixture = fixture;
+        }
+
+        [Fact]
+        public async Task ValidationSucceedsForDefaultModel()
+        {
+            using var db = new ValidDbContext(_fixture.DatabaseName);
+            var singerId = _fixture.RandomLong();
+            db.Singers.Add(new Singer
+            {
+                SingerId = singerId,
+                FirstName = "Alice",
+                LastName = "Tennet",
+            });
+            Assert.Equal(1, await db.SaveChangesAsync());
+        }
+
+        [Fact]
+        public void ValidationFailsForModelWithInvalidEntity()
+        {
+            using var db = new InvalidEntityDbContext(_fixture.DatabaseName);
+            Assert.Throws<InvalidOperationException>(() => db.Singers.Add(new Singer { }));
+        }
+
+        [Fact]
+        public void ValidationFailsForModelWithInvalidChildEntity()
+        {
+            using var db = new InvalidChildEntityDbContext(_fixture.DatabaseName);
+            Assert.Throws<InvalidOperationException>(() => db.Singers.Add(new Singer { }));
+        }
+
+        [Fact]
+        public async Task ValidationSucceedsForModelWithUniqueIndexAsKey()
+        {
+            using var db = new ModelWithUniqueIndexAsKeyDbContext(_fixture.DatabaseName);
+            var singerId = _fixture.RandomLong();
+            var albumId1 = _fixture.RandomLong();
+            var albumId2 = _fixture.RandomLong();
+            db.Singers.Add(new Singer
+            {
+                SingerId = singerId,
+                FirstName = "Nick",
+                LastName = "Bennetson",
+            });
+            db.Albums.AddRange(
+                new Album
+                {
+                    SingerId = singerId,
+                    AlbumId = albumId1,
+                    Title = $"Random title {albumId1}",
+                },
+                new Album
+                {
+                    SingerId = singerId,
+                    AlbumId = albumId2,
+                    Title = $"Random title {albumId2}",
+                });
+            Assert.Equal(3, await db.SaveChangesAsync());
+            // Verify that we can fetch an album using a (SingerId, Title) key.
+            // We do that in a new context to be sure that we actually fetch it from
+            // the database and not only the in-memory database context.
+            using var context = new ModelWithUniqueIndexAsKeyDbContext(_fixture.DatabaseName);
+            var album = await context.Albums.FindAsync(singerId, $"Random title {albumId2}");
+            Assert.Equal(albumId2, album.AlbumId);
+        }
+    }
+}

--- a/Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests/NonParallelTestCollection.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests/NonParallelTestCollection.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2021 Google Inc. All Rights Reserved.
+﻿// Copyright 2020 Google Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,15 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests.Model;
+using Xunit;
 
-namespace Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests.VersioningTests.Model
+namespace Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests
 {
-    public partial class AlbumsWithVersion : VersionedEntity
+    [CollectionDefinition(nameof(NonParallelTestCollection), DisableParallelization = true)]
+    public class NonParallelTestCollection
     {
-        public long AlbumId { get; set; }
-        public long SingerId { get; set; }
-        public string Title { get; set; }
-        public virtual SingersWithVersion Singer { get; set; }
     }
 }

--- a/Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests/NonParallelTestCollection.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests/NonParallelTestCollection.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Google Inc. All Rights Reserved.
+﻿// Copyright 2021 Google Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Google.Cloud.EntityFrameworkCore.Spanner.Tests/EntityFrameworkMockServerTests.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.Tests/EntityFrameworkMockServerTests.cs
@@ -16,6 +16,7 @@ using Google.Cloud.EntityFrameworkCore.Spanner.Extensions;
 using Google.Cloud.EntityFrameworkCore.Spanner.Infrastructure;
 using Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests.Model;
 using Google.Cloud.EntityFrameworkCore.Spanner.Storage;
+using Google.Cloud.EntityFrameworkCore.Spanner.Storage.Internal;
 using Google.Cloud.Spanner.Data;
 using Google.Cloud.Spanner.V1;
 using Google.Protobuf.WellKnownTypes;
@@ -47,7 +48,7 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
             if (!optionsBuilder.IsConfigured)
             {
                 optionsBuilder
-                    .UseSpanner(new SpannerConnection(_connectionString, ChannelCredentials.Insecure))
+                    .UseSpanner(_connectionString, _ => ModelValidationConnectionStringProvider.EnableDatabaseModelValidation(false), ChannelCredentials.Insecure)
                     .UseMutations(MutationUsage.Never)
                     .UseLazyLoadingProxies();
             }
@@ -68,7 +69,7 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
             if (!optionsBuilder.IsConfigured)
             {
                 optionsBuilder
-                    .UseSpanner(new SpannerConnection(_connectionString, ChannelCredentials.Insecure))
+                    .UseSpanner(_connectionString, _ => ModelValidationConnectionStringProvider.EnableDatabaseModelValidation(false), ChannelCredentials.Insecure)
                     .UseMutations(MutationUsage.Never)
                     .UseLazyLoadingProxies();
             }

--- a/Google.Cloud.EntityFrameworkCore.Spanner.Tests/EntityFrameworkMockServerTests.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.Tests/EntityFrameworkMockServerTests.cs
@@ -48,7 +48,7 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
             if (!optionsBuilder.IsConfigured)
             {
                 optionsBuilder
-                    .UseSpanner(_connectionString, _ => ModelValidationConnectionStringProvider.EnableDatabaseModelValidation(false), ChannelCredentials.Insecure)
+                    .UseSpanner(_connectionString, _ => SpannerModelValidationConnectionProvider.Instance.EnableDatabaseModelValidation(false), ChannelCredentials.Insecure)
                     .UseMutations(MutationUsage.Never)
                     .UseLazyLoadingProxies();
             }
@@ -69,7 +69,7 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
             if (!optionsBuilder.IsConfigured)
             {
                 optionsBuilder
-                    .UseSpanner(_connectionString, _ => ModelValidationConnectionStringProvider.EnableDatabaseModelValidation(false), ChannelCredentials.Insecure)
+                    .UseSpanner(_connectionString, _ => SpannerModelValidationConnectionProvider.Instance.EnableDatabaseModelValidation(false), ChannelCredentials.Insecure)
                     .UseMutations(MutationUsage.Never)
                     .UseLazyLoadingProxies();
             }

--- a/Google.Cloud.EntityFrameworkCore.Spanner.Tests/EntityFrameworkUsingMutationsMockServerTests.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.Tests/EntityFrameworkUsingMutationsMockServerTests.cs
@@ -45,7 +45,7 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
             if (!optionsBuilder.IsConfigured)
             {
                 optionsBuilder
-                    .UseSpanner(new SpannerConnection(_connectionString, ChannelCredentials.Insecure))
+                    .UseSpanner(_connectionString, _ => ModelValidationConnectionStringProvider.EnableDatabaseModelValidation(false), ChannelCredentials.Insecure)
                     .UseMutations(MutationUsage.Always)
                     .UseLazyLoadingProxies();
             }
@@ -66,7 +66,7 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
             if (!optionsBuilder.IsConfigured)
             {
                 optionsBuilder
-                    .UseSpanner(new SpannerConnection(_connectionString, ChannelCredentials.Insecure))
+                    .UseSpanner(_connectionString, _ => ModelValidationConnectionStringProvider.EnableDatabaseModelValidation(false), ChannelCredentials.Insecure)
                     .UseMutations(MutationUsage.Always)
                     .UseLazyLoadingProxies();
             }

--- a/Google.Cloud.EntityFrameworkCore.Spanner.Tests/EntityFrameworkUsingMutationsMockServerTests.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.Tests/EntityFrameworkUsingMutationsMockServerTests.cs
@@ -45,7 +45,7 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
             if (!optionsBuilder.IsConfigured)
             {
                 optionsBuilder
-                    .UseSpanner(_connectionString, _ => ModelValidationConnectionStringProvider.EnableDatabaseModelValidation(false), ChannelCredentials.Insecure)
+                    .UseSpanner(_connectionString, _ => SpannerModelValidationConnectionProvider.Instance.EnableDatabaseModelValidation(false), ChannelCredentials.Insecure)
                     .UseMutations(MutationUsage.Always)
                     .UseLazyLoadingProxies();
             }
@@ -66,7 +66,7 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
             if (!optionsBuilder.IsConfigured)
             {
                 optionsBuilder
-                    .UseSpanner(_connectionString, _ => ModelValidationConnectionStringProvider.EnableDatabaseModelValidation(false), ChannelCredentials.Insecure)
+                    .UseSpanner(_connectionString, _ => SpannerModelValidationConnectionProvider.Instance.EnableDatabaseModelValidation(false), ChannelCredentials.Insecure)
                     .UseMutations(MutationUsage.Always)
                     .UseLazyLoadingProxies();
             }

--- a/Google.Cloud.EntityFrameworkCore.Spanner.Tests/MigrationTests/GenerateCreateScriptTest.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.Tests/MigrationTests/GenerateCreateScriptTest.cs
@@ -30,7 +30,7 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests.MigrationTests
         {
             if (!optionsBuilder.IsConfigured)
             {
-                optionsBuilder.UseSpanner("Data Source=projects/p1/instances/i1/databases/d1;", _ => ModelValidationConnectionStringProvider.EnableDatabaseModelValidation(false));
+                optionsBuilder.UseSpanner("Data Source=projects/p1/instances/i1/databases/d1;", _ => SpannerModelValidationConnectionProvider.Instance.EnableDatabaseModelValidation(false));
             }
         }
     }

--- a/Google.Cloud.EntityFrameworkCore.Spanner.Tests/MigrationTests/GenerateCreateScriptTest.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.Tests/MigrationTests/GenerateCreateScriptTest.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Google.Cloud.EntityFrameworkCore.Spanner.Extensions;
 using Google.Cloud.EntityFrameworkCore.Spanner.Tests.MigrationTests.Models;
 using Microsoft.EntityFrameworkCore;
 using System.IO;
@@ -29,7 +30,7 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests.MigrationTests
         {
             if (!optionsBuilder.IsConfigured)
             {
-                optionsBuilder.UseSpanner("Data Source=projects/p1/instances/i1/databases/d1;");
+                optionsBuilder.UseSpanner("Data Source=projects/p1/instances/i1/databases/d1;", _ => ModelValidationConnectionStringProvider.EnableDatabaseModelValidation(false));
             }
         }
     }

--- a/Google.Cloud.EntityFrameworkCore.Spanner.Tests/Migrations/MigrationSqlGeneratorTestBase.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.Tests/Migrations/MigrationSqlGeneratorTestBase.cs
@@ -12,10 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using Google.Cloud.EntityFrameworkCore.Spanner.Extensions;
 using Google.Cloud.EntityFrameworkCore.Spanner.Storage;
 using Google.Cloud.EntityFrameworkCore.Spanner.Tests.TestUtilities;
 using Google.Cloud.Spanner.V1;
@@ -25,6 +21,9 @@ using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations;
 using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using Xunit;
 
 namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests.Migrations

--- a/Google.Cloud.EntityFrameworkCore.Spanner.Tests/Migrations/MigrationSqlGeneratorTestBase.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.Tests/Migrations/MigrationSqlGeneratorTestBase.cs
@@ -15,6 +15,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Google.Cloud.EntityFrameworkCore.Spanner.Extensions;
 using Google.Cloud.EntityFrameworkCore.Spanner.Storage;
 using Google.Cloud.EntityFrameworkCore.Spanner.Tests.TestUtilities;
 using Google.Cloud.Spanner.V1;

--- a/Google.Cloud.EntityFrameworkCore.Spanner.Tests/Migrations/SpannerHistoryRepositoryTest.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.Tests/Migrations/SpannerHistoryRepositoryTest.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Google.Cloud.EntityFrameworkCore.Spanner.Extensions;
 using Google.Cloud.EntityFrameworkCore.Spanner.Migrations.Internal;
 using Google.Cloud.EntityFrameworkCore.Spanner.Tests.TestUtilities;
 using Google.Cloud.Spanner.Data;
@@ -51,7 +52,11 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests.Migrations
                 .UseSpanner(
                     new SpannerConnection("Data Source=projects/p1/instances/i1/databases/d1"),
 
-                    b => b.MigrationsHistoryTable(SpannerHistoryRepository.DefaultMigrationsHistoryTableName, schema))
+                    b =>
+                    {
+                        SpannerModelValidationConnectionProvider.Instance.EnableDatabaseModelValidation(false);
+                        b.MigrationsHistoryTable(SpannerHistoryRepository.DefaultMigrationsHistoryTableName, schema);
+                    })
                 .Options)
         .GetService<IHistoryRepository>();
     }

--- a/Google.Cloud.EntityFrameworkCore.Spanner.Tests/Migrations/SpannerMigrationSqlGeneratorTest.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.Tests/Migrations/SpannerMigrationSqlGeneratorTest.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Google.Cloud.EntityFrameworkCore.Spanner.Extensions;
 using Google.Cloud.EntityFrameworkCore.Spanner.Tests.TestUtilities;
 using Microsoft.EntityFrameworkCore.Migrations.Operations;
 using System;

--- a/Google.Cloud.EntityFrameworkCore.Spanner.Tests/Migrations/SpannerMigrationSqlGeneratorTest.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.Tests/Migrations/SpannerMigrationSqlGeneratorTest.cs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Google.Cloud.EntityFrameworkCore.Spanner.Extensions;
 using Google.Cloud.EntityFrameworkCore.Spanner.Tests.TestUtilities;
 using Microsoft.EntityFrameworkCore.Migrations.Operations;
 using System;

--- a/Google.Cloud.EntityFrameworkCore.Spanner.Tests/TestUtilities/SpannerTestHelpers.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.Tests/TestUtilities/SpannerTestHelpers.cs
@@ -31,6 +31,9 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests.TestUtilities
             => services.AddEntityFrameworkSpanner();
 
         protected override void UseProviderOptions(DbContextOptionsBuilder optionsBuilder)
-            => optionsBuilder.UseSpanner(new SpannerConnection("Data Source=projects/p1/instances/i1/databases/d1"));
+        {
+            optionsBuilder.UseSpanner(new SpannerConnection("Data Source=projects/p1/instances/i1/databases/d1"));
+            SpannerModelValidationConnectionProvider.Instance.EnableDatabaseModelValidation(false);
+        }
     }
 }

--- a/Google.Cloud.EntityFrameworkCore.Spanner/Extensions/Internal/ModelValidationConnectionStringProvider.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner/Extensions/Internal/ModelValidationConnectionStringProvider.cs
@@ -1,0 +1,120 @@
+﻿// Copyright 2021, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Cloud.Spanner.Data;
+using Grpc.Core;
+
+namespace Google.Cloud.EntityFrameworkCore.Spanner.Extensions
+{
+    /// <summary>
+    /// This is internal functionality and not intended for public use.
+    /// 
+    /// ModelValidationConnectionStringProvider is registered as a singleton service that provides a
+    /// connection string to the Spanner database that is used with EF Core. This provider will only
+    /// return a connection string as long as the application is only connecting one database. If the
+    /// application uses EF Core to connect to multiple different Spanner databases, the provider will
+    /// return null.
+    /// 
+    /// The connection string that is returned by this provider can be used by the SpannerModelValidator
+    /// to check the entity model that is used against the database, to check for common misconfigurations.
+    /// </summary>
+    public class ModelValidationConnectionStringProvider
+    {
+        public static readonly ModelValidationConnectionStringProvider Instance = new ModelValidationConnectionStringProvider();
+
+        /// <summary>
+        /// This is internal functionality and not intended for public use.
+        /// 
+        /// Resets the connection string provider to its initial state. This will (re-)enable model validation against
+        /// an actual database. Calling this in a multi-threaded environment that accesses multiple different Spanner
+        /// databases can cause random validation errors.
+        /// </summary>
+        public static void Reset()
+        {
+            lock (Instance.lck)
+            {
+                Instance._connectionString = null;
+                Instance._channelCredentials = null;
+                Instance._connectionStringBuilder = null;
+            }
+        }
+
+        public static void EnableDatabaseModelValidation(bool enable)
+        {
+            lock (Instance.lck)
+            {
+                Instance._enabled = enable;
+            }
+        }
+
+        private readonly object lck = new object();
+        private bool _enabled = true;
+        private string _connectionString;
+        private ChannelCredentials _channelCredentials;
+        private SpannerConnectionStringBuilder _connectionStringBuilder;
+
+        private ModelValidationConnectionStringProvider()
+        {
+        }
+
+        public SpannerConnection GetConnection()
+        {
+            lock (lck)
+            {
+                return !_enabled || _connectionString == null ? null : new SpannerConnection(_connectionString, _channelCredentials);
+            }
+        }
+
+        internal void SetConnectionString(string value, ChannelCredentials channelCredentials = null)
+        {
+            lock (lck)
+            {
+                if (_connectionString == null && _connectionStringBuilder != null)
+                {
+                    // This means that the provider has already seen at least two different
+                    // connection strings.
+                    return;
+                }
+
+                var builder = new SpannerConnectionStringBuilder(value);
+                // Ignore connection strings without a valid database.
+                if (builder.DatabaseName == null)
+                {
+                    return;
+                }
+                // Check if this is the first valid connection string that has been set.
+                // If so, register this as THE connection string and use that for validation.
+                if (_connectionString == null && _connectionStringBuilder == null)
+                {
+                    // This is the first valid connection string.
+                    _connectionStringBuilder = builder;
+                    _connectionString = value;
+                    _channelCredentials = channelCredentials;
+                    return;
+                }
+                // This is not the first valid connection string. Check whether the new
+                // connection string is connecting to the same database. If it is, it is
+                // still safe to do validation against the database.
+                if (!builder.DatabaseName.Equals(_connectionStringBuilder.DatabaseName))
+                {
+                    // The application is connecting to a new database. It is no longer safe
+                    // to validate against the database, as there is no guarantee that the
+                    // order of validation will be equal to the order of calling UseSpanner(connectionString).
+                    _connectionString = null;
+                    _channelCredentials = null;
+                }
+            }
+        }
+    }
+}

--- a/Google.Cloud.EntityFrameworkCore.Spanner/Extensions/Internal/SpannerModelValidationConnectionProvider.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner/Extensions/Internal/SpannerModelValidationConnectionProvider.cs
@@ -20,7 +20,7 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Extensions
     /// <summary>
     /// ModelValidationConnectionProvider is registered as a singleton service that provides a
     /// connection to the Spanner database that is used with Entity Framework. This provider will only
-    /// return a connection as long as the application is only connecting one database. If the
+    /// return a connection as long as the application is only connecting to one database. If the
     /// application uses Entity Framework to connect to multiple different Spanner databases, the provider will
     /// return null.
     /// 

--- a/Google.Cloud.EntityFrameworkCore.Spanner/Extensions/SpannerDatabaseFacadeExtensions.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner/Extensions/SpannerDatabaseFacadeExtensions.cs
@@ -17,7 +17,6 @@ using Google.Cloud.EntityFrameworkCore.Spanner.Storage.Internal;
 using Google.Cloud.Spanner.Data;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage;
 using System;
 using System.Threading;

--- a/Google.Cloud.EntityFrameworkCore.Spanner/Extensions/SpannerDatabaseFacadeExtensions.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner/Extensions/SpannerDatabaseFacadeExtensions.cs
@@ -17,6 +17,7 @@ using Google.Cloud.EntityFrameworkCore.Spanner.Storage.Internal;
 using Google.Cloud.Spanner.Data;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage;
 using System;
 using System.Threading;

--- a/Google.Cloud.EntityFrameworkCore.Spanner/Extensions/SpannerServiceCollectionExtensions.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner/Extensions/SpannerServiceCollectionExtensions.cs
@@ -60,7 +60,7 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Extensions
                 .TryAdd<IMemberTranslatorProvider, SpannerMemberTranslatorProvider>()
                 .TryAdd<IRelationalConnection>(p => p.GetService<ISpannerRelationalConnection>())
                 .TryAdd<IModelValidator, SpannerModelValidator>()
-                .TryAddProviderSpecificServices(p => p.TryAddSingleton(_ => ModelValidationConnectionStringProvider.Instance))
+                .TryAddProviderSpecificServices(p => p.TryAddSingleton(_ => SpannerModelValidationConnectionProvider.Instance))
                 .TryAdd<IMigrationsSqlGenerator, SpannerMigrationsSqlGenerator>()
                 .TryAdd<IMigrationCommandExecutor, SpannerMigrationCommandExecutor>()
                 .TryAdd<IRelationalDatabaseCreator, SpannerDatabaseCreator>()

--- a/Google.Cloud.EntityFrameworkCore.Spanner/Extensions/SpannerServiceCollectionExtensions.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner/Extensions/SpannerServiceCollectionExtensions.cs
@@ -28,9 +28,11 @@ using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Update;
 using Microsoft.Extensions.DependencyInjection;
+using System;
 
 namespace Google.Cloud.EntityFrameworkCore.Spanner.Extensions
 {
+
     /// <summary>
     /// Spanner specific extension methods for <see cref="IServiceCollection" />.
     /// </summary>
@@ -53,11 +55,12 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Extensions
                 .TryAdd<IUpdateSqlGenerator, SpannerUpdateSqlGenerator>()
                 .TryAdd<IBatchExecutor, SpannerBatchExecutor>()
                 .TryAdd<IModificationCommandBatchFactory, SpannerModificationCommandBatchFactory>()
-                .TryAdd<IModelValidator, RelationalModelValidator>()
                 .TryAdd<IQuerySqlGeneratorFactory, SpannerQuerySqlGeneratorFactory>()
                 .TryAdd<IMethodCallTranslatorProvider, SpannerMethodCallTranslatorProvider>()
                 .TryAdd<IMemberTranslatorProvider, SpannerMemberTranslatorProvider>()
                 .TryAdd<IRelationalConnection>(p => p.GetService<ISpannerRelationalConnection>())
+                .TryAdd<IModelValidator, SpannerModelValidator>()
+                .TryAddProviderSpecificServices(p => p.TryAddSingleton(_ => ModelValidationConnectionStringProvider.Instance))
                 .TryAdd<IMigrationsSqlGenerator, SpannerMigrationsSqlGenerator>()
                 .TryAdd<IMigrationCommandExecutor, SpannerMigrationCommandExecutor>()
                 .TryAdd<IRelationalDatabaseCreator, SpannerDatabaseCreator>()
@@ -67,6 +70,7 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Extensions
                   .TryAddScoped<ISpannerRelationalConnection, SpannerRelationalConnection>()
                 );
             builder.TryAddCoreServices();
+
             return serviceCollection;
         }
     }

--- a/Google.Cloud.EntityFrameworkCore.Spanner/Extensions/SpannerServiceCollectionExtensions.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner/Extensions/SpannerServiceCollectionExtensions.cs
@@ -28,11 +28,9 @@ using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Update;
 using Microsoft.Extensions.DependencyInjection;
-using System;
 
 namespace Google.Cloud.EntityFrameworkCore.Spanner.Extensions
 {
-
     /// <summary>
     /// Spanner specific extension methods for <see cref="IServiceCollection" />.
     /// </summary>
@@ -70,7 +68,6 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Extensions
                   .TryAddScoped<ISpannerRelationalConnection, SpannerRelationalConnection>()
                 );
             builder.TryAddCoreServices();
-
             return serviceCollection;
         }
     }

--- a/Google.Cloud.EntityFrameworkCore.Spanner/Google.Cloud.EntityFrameworkCore.Spanner.csproj
+++ b/Google.Cloud.EntityFrameworkCore.Spanner/Google.Cloud.EntityFrameworkCore.Spanner.csproj
@@ -20,6 +20,7 @@
   <ItemGroup>
     <PackageReference Include="Google.Cloud.Spanner.Data" Version="3.4.0" />
     <PackageReference Include="JetBrains.Annotations" Version="2020.3.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="3.1.0" />
     <PackageReference Include="OpenTelemetry.Api" Version="1.0.1" />
   </ItemGroup>

--- a/Google.Cloud.EntityFrameworkCore.Spanner/Infrastructure/Internal/SpannerModelValidator.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner/Infrastructure/Internal/SpannerModelValidator.cs
@@ -1,0 +1,125 @@
+﻿// Copyright 2021, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Cloud.EntityFrameworkCore.Spanner.Extensions;
+using Google.Cloud.Spanner.Data;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Linq;
+
+namespace Google.Cloud.EntityFrameworkCore.Spanner.Infrastructure.Internal
+{
+    public class SpannerModelValidator : RelationalModelValidator
+    {
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public SpannerModelValidator(
+            ModelValidationConnectionStringProvider connectionStringProvider,
+            ModelValidatorDependencies dependencies,
+            RelationalModelValidatorDependencies relationalDependencies)
+            : base(dependencies, relationalDependencies)
+            => ConnectionStringProvider = connectionStringProvider;
+
+        internal ModelValidationConnectionStringProvider ConnectionStringProvider { get; }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public override void Validate(IModel model, IDiagnosticsLogger<DbLoggerCategory.Model.Validation> logger)
+        {
+            base.Validate(model, logger);
+            ValidateKeysCorrespondWithDataModel(model);
+        }
+
+        /// <summary>
+        /// Validates that all entities have a key definition and that the key definition corresponds with an actual
+        /// non-null-filtered unique key in the database.
+        /// </summary>
+        protected virtual void ValidateKeysCorrespondWithDataModel(IModel model)
+        {
+            using var connection = ConnectionStringProvider.GetConnection();
+            if (connection == null)
+            {
+                return;
+            }
+
+            var commandText = @"SELECT I.TABLE_NAME, I.INDEX_NAME, C.COLUMN_NAME 
+                                FROM INFORMATION_SCHEMA.INDEXES I
+                                INNER JOIN INFORMATION_SCHEMA.INDEX_COLUMNS C ON
+		                                I.TABLE_CATALOG = C.TABLE_CATALOG AND
+		                                I.TABLE_SCHEMA = C.TABLE_SCHEMA AND
+		                                I.TABLE_NAME = C.TABLE_NAME AND
+		                                I.INDEX_NAME = C.INDEX_NAME
+                                WHERE I.TABLE_CATALOG = ''
+                                  AND I.TABLE_SCHEMA = ''
+                                  AND I.IS_UNIQUE = TRUE
+                                  AND I.IS_NULL_FILTERED = FALSE
+                                ORDER BY I.TABLE_CATALOG, I.TABLE_SCHEMA, I.TABLE_NAME, I.INDEX_NAME, C.ORDINAL_POSITION";
+            using var cmd = connection.CreateSelectCommand(commandText);
+            using var reader = cmd.ExecuteReader();
+            var tableKeyColumnsGroups = reader.Cast<DbDataRecord>()
+                .GroupBy(ddr => (
+                    Table: ddr.GetString(ddr.GetOrdinal("TABLE_NAME")),
+                    Index: ddr.GetString(ddr.GetOrdinal("INDEX_NAME"))));
+            var tableKeyColumns = new Dictionary<string, List<List<string>>>();
+            foreach (var tableKeyColumnGroup in tableKeyColumnsGroups)
+            {
+                var table = tableKeyColumnGroup.Key.Table;
+                var index = tableKeyColumnGroup.Key.Index;
+                var columns = tableKeyColumnGroup.Select(col => col.GetString(col.GetOrdinal("COLUMN_NAME"))).ToList();
+                if (!tableKeyColumns.TryGetValue(table, out List<List<string>> allIndexedColumns))
+                {
+                    allIndexedColumns = new List<List<string>>();
+                    tableKeyColumns.Add(table, allIndexedColumns);
+                }
+                allIndexedColumns.Add(columns);
+            }
+
+            foreach (var entityType in model.GetEntityTypes())
+            {
+                var table = entityType.GetTableName();
+                var pk = entityType.FindPrimaryKey();
+                if (pk == null)
+                {
+                    // This is handled by the base validator.
+                    continue;
+                }
+                var keyColumns = pk.Properties.Select(p => p.GetColumnName()).ToList();
+                if (tableKeyColumns.TryGetValue(table, out var allIndexedDbColumns))
+                {
+                    if (!allIndexedDbColumns.Where(dbKeyColumns => Enumerable.SequenceEqual(keyColumns, dbKeyColumns)).Any())
+                    {
+                        throw new InvalidOperationException($"No primary key or other unique index was found in the database for table {table} for key column(s) ({string.Join(", ", keyColumns)})");
+                    }
+                }
+                else
+                {
+                    throw new InvalidOperationException($"No primary key was found in the database for table {table}");
+                }
+            }
+        }
+    }
+}

--- a/Google.Cloud.EntityFrameworkCore.Spanner/Infrastructure/Internal/SpannerModelValidator.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner/Infrastructure/Internal/SpannerModelValidator.cs
@@ -15,6 +15,7 @@
 using Google.Cloud.EntityFrameworkCore.Spanner.Extensions;
 using Google.Cloud.Spanner.Data;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Design.Internal;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
@@ -73,13 +74,30 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Infrastructure.Internal
             // In that case we should also skip the further validation, as the differences
             // could be a result of migrations that still need to be executed.
             var facadeExtensions = nameof(RelationalDatabaseFacadeExtensions);
-            var migrateMethods = new List<string> { nameof(RelationalDatabaseFacadeExtensions.Migrate), nameof(RelationalDatabaseFacadeExtensions.MigrateAsync) };
+            var migrateMethods = new List<string>
+            {
+                nameof(RelationalDatabaseFacadeExtensions.Migrate),
+                nameof(RelationalDatabaseFacadeExtensions.MigrateAsync),
+            };
+            var migrationsOperations = nameof(MigrationsOperations);
+            var migrationsOperationsMethods = new List<string>
+            {
+                nameof(MigrationsOperations.AddMigration),
+                nameof(MigrationsOperations.GetMigrations),
+                nameof(MigrationsOperations.RemoveMigration),
+                nameof(MigrationsOperations.ScriptMigration),
+                nameof(MigrationsOperations.UpdateDatabase),
+            };
             int skipFrames = 1;
             MethodBase method = null;
             do
             {
                 method = new StackFrame(skipFrames, false).GetMethod();
                 if (method != null && migrateMethods.Contains(method.Name) && facadeExtensions.Equals(method.DeclaringType.Name))
+                {
+                    return;
+                }
+                if (method != null && migrationsOperationsMethods.Contains(method.Name) && migrationsOperations.Equals(method.DeclaringType.Name))
                 {
                     return;
                 }


### PR DESCRIPTION
Adds validation of the entity model that is used against the actual database. The current validation only adds a check for the key that is used for each entity, but the setup could be used for additional validations in the future.

The check for the key that is set on an entity verifies that:
1. The key of the entity corresponds exactly with the columns of the primary key of the table
2. OR the key of the entity corresponds exactly with the columns of another unique not null-filtered index on the table.

This type of validation is not really supported by Entity Framework itself. The built-in model validation is intended to only validate the __model__, and not whether the model corresponds with the database. The support that is added in this PR is therefore limited:
1. The model validator relies on a singleton `SpannerModelValidationConnectionProvider` that provides a connection to the database.
2. If the application uses multiple different databases, the connection provider will detect this, and stop providing a connection, as there is no hard link between the moment a model validation occurs and when a connection is given to the connection provider through the `UseSpanner` method. This effectively disables model validation against the database for the remainder of the lifetime of the application. The normal model validation that is built into EF Core will still work.
3. Model validation against the database can also be manually disabled by calling `SpannerModelValidationConnectionProvider.Instance.EnableDatabaseModelValidation(true)`.
4. Model validation against the database is automatically disabled when running migrations, as during a migration there might be differences between the entity model and the database.
5. Model validation against the database is a relatively heavy operation. It is however only executed once for each model during the lifetime of the application.
