### PR TITLE
feat: propagate commit timestamp to current DbContext

### DIFF
--- a/Google.Cloud.EntityFrameworkCore.Spanner.Samples/SampleModel/SampleDataModel.sql
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.Samples/SampleModel/SampleDataModel.sql
@@ -62,4 +62,4 @@ CREATE TABLE Performances (
   CONSTRAINT FK_Performances_Concerts FOREIGN KEY (VenueCode, ConcertStartTime, SingerId) REFERENCES Concerts (VenueCode, StartTime, SingerId),
   CONSTRAINT FK_Performances_Singers FOREIGN KEY (SingerId) REFERENCES Singers (SingerId),
   CONSTRAINT FK_Performances_Tracks FOREIGN KEY (AlbumId, TrackId) REFERENCES Tracks (AlbumId, TrackId),
-) PRIMARY KEY (VenueCode, SingerId, StartTime);
+) PRIMARY KEY (VenueCode, StartTime, SingerId);

--- a/Google.Cloud.EntityFrameworkCore.Spanner.Samples/SampleModel/SpannerSampleDbContext.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.Samples/SampleModel/SpannerSampleDbContext.cs
@@ -92,16 +92,19 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Samples.SampleModel
 
             modelBuilder.Entity<Concert>(entity =>
             {
-                entity.HasKey(entity => new { entity.VenueCode, entity.SingerId, entity.StartTime });
+                entity.HasKey(entity => new { entity.VenueCode, entity.StartTime, entity.SingerId });
                 entity.Property(e => e.Version).IsConcurrencyToken();
             });
 
             modelBuilder.Entity<Performance>(entity =>
             {
-                entity.HasKey(entity => new { entity.VenueCode, entity.SingerId, entity.StartTime });
+                entity.HasKey(entity => new { entity.VenueCode, entity.StartTime, entity.SingerId });
                 entity.Property(e => e.Version).IsConcurrencyToken();
 
                 // Specify when the CreateAt and LastUpdatedAt columns should be updated.
+                // You can also use SpannerUpdateCommitTimestamp.OnInsertAndUpdate to specify
+                // that the commit timestamp should be updated both for inserts AND updates.
+                // Note that these properties are NOT marked as generated with ValueGeneratedOnAddOrUpdate().
                 entity.Property(e => e.CreatedAt)
                     .HasAnnotation(SpannerAnnotationNames.UpdateCommitTimestamp, SpannerUpdateCommitTimestamp.OnInsert);
                 entity.Property(e => e.LastUpdatedAt)
@@ -122,7 +125,7 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Samples.SampleModel
 
                 entity.HasOne(d => d.Concert)
                     .WithMany(p => p.Performances)
-                    .HasForeignKey(d => new { d.VenueCode, d.SingerId, d.ConcertStartTime })
+                    .HasForeignKey(d => new { d.VenueCode, d.ConcertStartTime, d.SingerId })
                     .OnDelete(DeleteBehavior.ClientSetNull);
             });
 

--- a/Google.Cloud.EntityFrameworkCore.Spanner/Storage/Internal/SpannerRetriableTransaction.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner/Storage/Internal/SpannerRetriableTransaction.cs
@@ -14,6 +14,7 @@
 
 using Google.Api.Gax;
 using Google.Cloud.EntityFrameworkCore.Spanner.Extensions;
+using Google.Cloud.EntityFrameworkCore.Spanner.Update.Internal;
 using Google.Cloud.Spanner.Data;
 using Grpc.Core;
 using System;
@@ -83,6 +84,7 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Storage.Internal
         private readonly IScheduler _scheduler;
         private readonly RetriableTransactionOptions _options;
         private readonly List<IRetriableStatement> _retriableStatements = new List<IRetriableStatement>();
+        private readonly List<SpannerPendingCommitTimestampModificationCommand> _commitTimestampModificationCommands = new List<SpannerPendingCommitTimestampModificationCommand>();
         public int RetryCount { get; private set; }
 
         internal SpannerRetriableTransaction(
@@ -280,6 +282,11 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Storage.Internal
             }
         }
 
+        internal void AddSpannerPendingCommitTimestampModificationCommand(SpannerPendingCommitTimestampModificationCommand modificationCommand)
+        {
+            _commitTimestampModificationCommands.Add(modificationCommand);
+        }
+
         /// <summary>
         /// Commits the database transaction asynchronously.
         /// </summary>
@@ -294,6 +301,25 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Storage.Internal
                 try
                 {
                     _commitTimestamp = await SpannerTransaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+                    foreach (var modificationCommand in _commitTimestampModificationCommands)
+                    {
+                        foreach (var columnModification in modificationCommand.ColumnModifications)
+                        {
+                            if (columnModification is SpannerPendingCommitTimestampColumnModification pendingCommitTimestampColumnModification)
+                            {
+                                var property = pendingCommitTimestampColumnModification.Property.PropertyInfo;
+                                if (property != null)
+                                {
+                                    var entry = pendingCommitTimestampColumnModification.Entry;
+                                    var originalState = entry.EntityState;
+                                    var entity = entry.ToEntityEntry().Entity;
+                                    property.SetValue(entity, _commitTimestamp);
+                                    entry.EntityState = originalState;
+                                }
+                            }
+                        }
+
+                    }
                     span.SetStatus(OpenTelemetry.Trace.Status.Ok);
                     span.End();
                     return (DateTime)_commitTimestamp;

--- a/Google.Cloud.EntityFrameworkCore.Spanner/Update/Internal/SpannerModificationCommandBatch .cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner/Update/Internal/SpannerModificationCommandBatch .cs
@@ -211,6 +211,7 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Update.Internal
                 if (modificationCommand is SpannerPendingCommitTimestampModificationCommand commitTimestampModificationCommand)
                 {
                     commitTimestampModificationCommand.MarkAsMutationCommand();
+                    transaction.AddSpannerPendingCommitTimestampModificationCommand(commitTimestampModificationCommand);
                 }
                 // Create the mutation command and execute it.
                 var cmd = CreateSpannerMutationCommand(spannerConnection, transaction, modificationCommand);
@@ -344,6 +345,10 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Update.Internal
                         commands.Item2.Transaction = transaction;
                     }
                     selectCommands.Add(commands.Item2);
+                }
+                if (modificationCommand is SpannerPendingCommitTimestampModificationCommand commitTimestampModificationCommand)
+                {
+                    transaction.AddSpannerPendingCommitTimestampModificationCommand(commitTimestampModificationCommand);
                 }
                 commandPosition++;
             }

--- a/README.md
+++ b/README.md
@@ -284,25 +284,6 @@ side Guid generator for a primary key if your table does not contain a natural p
 ## Default Values
 Cloud Spanner does not support default values for columns.
 
-## Commit Timestamps are not Visible in the Same DbContext
-Commit timestamps that are filled automatically using the `UpdateCommitTimestamp` annotation (see above) are not visible
-in the same `DbContext` that wrote it. The reason for this is that:
-1. A commit timestamp can only be read after the transaction has committed.
-2. EF Core will propagate values that are automatically updated by the database in the same transaction as the transaction that executed the update.
-
-The automatic propagation of commit timestamps is therefore disabled by the Spanner EF Core provider.
-
-A workaround for this problem is to force  refresh of the entity:
-
-```cs
-var singer = new Singer { SingerId = 1, ... };
-await context.SaveChangesAsync();
-// Refresh the singer entity to get the most recent commit timestamp.
-context.Entry(singer).State = Microsoft.EntityFrameworkCore.EntityState.Detached;
-singer = await context.Singers.FindAsync(1);
-Console.WriteLine($"Singer was created at {singer.CreatedAt}");
-```
-
 # Create and publish a NuGet package locally using Visual Studio
 
 ### 1. Pack your Package from the Source Code


### PR DESCRIPTION
Propagates an automatically generated commit timestamp to the entity in the current `DbContext`. This removes the requirement to detach and re-fetch an entity to get a newly generated commit timestamp.

Fixes #10